### PR TITLE
Convert underscores to dashes in Debian package name

### DIFF
--- a/make.go
+++ b/make.go
@@ -307,7 +307,7 @@ func debianNameFromGopkg(gopkg, t string) string {
 		}
 	}
 	parts[0] = host
-	return "golang-" + strings.ToLower(strings.Join(parts, "-"))
+	return "golang-" + strings.ToLower(strings.Replace(strings.Join(parts, "-"), "_", "-", -1))
 }
 
 func getDebianName() string {


### PR DESCRIPTION
For rare cases like https://github.com/shurcooL/sanitized_anchor_name
that is needed by the latest https://github.com/russross/blackfriday.

----

@stapelberg, I would like to expressing my deepest gratitude for dh-make-golang, and ingenious piece of software that makes Go packaging on Debian so magical and delightful!  And suddenly, the task of packaging https://github.com/spf13/hugo for Debian becomes so much easier!  :-)