### PR TITLE
Add X-Debbugs-CC to ITP mail header

### DIFF
--- a/make.go
+++ b/make.go
@@ -511,6 +511,7 @@ func writeITP(gopkg, debsrc, debversion string) (string, error) {
 	fmt.Fprintf(f, "Subject: ITP: %s -- %s\n", debsrc, description)
 	fmt.Fprintf(f, "Content-Type: text/plain; charset=utf-8\n")
 	fmt.Fprintf(f, "Content-Transfer-Encoding: 8bit\n")
+	fmt.Fprintf(f, "X-Debbugs-CC: debian-devel@lists.debian.org, pkg-go-maintainers@lists.alioth.debian.org\n")
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "Package: wnpp\n")
 	fmt.Fprintf(f, "Severity: wishlist\n")


### PR DESCRIPTION
Forwarding to debian-devel@lists.debian.org as per recommendation at https://www.debian.org/doc/manuals/developers-reference/pkgs.html#newpackage

As for forwarding to pkg-go-maintainers@lists.alioth.debian.org, it appears to be a rather common practice to do the same for new Python package ITPs that get forwarded to debian-python@lists.debian.org.  :-)
