### PR TITLE
Compress source tarball with xz instead of bzip2

### DIFF
--- a/make.go
+++ b/make.go
@@ -95,7 +95,7 @@ func makeUpstreamSourceTarball(gopkg string) (string, string, map[string]bool, s
 	dir := filepath.Dir(gopkg)
 	cmd = exec.Command(
 		"tar",
-		"cjf",
+		"cJf",
 		tempfile,
 		"--exclude-vcs",
 		"--exclude=Godeps",
@@ -653,7 +653,7 @@ func main() {
 	}
 	golangBinariesMu.RUnlock()
 
-	orig := fmt.Sprintf("%s_%s.orig.tar.bz2", debsrc, version)
+	orig := fmt.Sprintf("%s_%s.orig.tar.xz", debsrc, version)
 	// We need to copy the file, merely renaming is not enough since the file
 	// might be on a different filesystem (/tmp often is a tmpfs).
 	if err := copyFile(tempfile, orig); err != nil {


### PR DESCRIPTION
Hello,

This suggested pull request might be controversial, as creating .orig.tar.bz2 or .orig.tar.xz is both valid and accepted by Debian, and the choice often comes down to a bit of a personal preference.

That said, there are often small but substantial space saving that we can have by compressing with xz, so I think it would be great for dh-make-golang to use xz for compression by default.  :-)

Or, would you rather make it a configurable option?