### PR TITLE
Prevent error when there is no dependencies

### DIFF
--- a/make.go
+++ b/make.go
@@ -183,6 +183,10 @@ func makeUpstreamSourceTarball(gopkg string) (string, string, map[string]bool, s
 		}
 	}
 
+	if len(godependencies) == 0 {
+		return tempfile, version, dependencies, autoPkgType, nil
+	}
+
 	// Remove all packages which are in the standard lib.
 	args := []string{"list", "-f", "{{.ImportPath}}: {{.Standard}}"}
 	args = append(args, godependencies...)


### PR DESCRIPTION
Avoid running `go list -f '{{.ImportPath}}: {{.Standard}}'`
with no dependencies listed, as the command would lead to the
following error otherwise:

    can't load package: package .: no buildable Go source files in /current/path
    Could not create a tarball of the upstream source: exit status 1

----

This strange corner case is with https://github.com/inconshreveable/mousetrap which simply returns `false` on non-Windows platform, thus requiring no dependencies on Linux, and thus triggering the bug:

```
foka@debian:/work/debian/go$ dh-make-golang github.com/inconshreveable/mousetrap
2015/09/08 04:52:44 Downloading "github.com/inconshreveable/mousetrap/..."
2015/09/08 04:52:45 Determining upstream version number
2015/09/08 04:52:45 Package version is "0.0~git20141017.0.76626ae"
2015/09/08 04:52:45 Determining package type
2015/09/08 04:52:45 Determining dependencies
can't load package: package .: no buildable Go source files in /work/debian/go
2015/09/08 04:52:45 Could not create a tarball of the upstream source: exit status 1
foka@debian:/work/debian/go$ 
```