### PR TITLE
Fix an error when git config is called.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Michael Stapelberg and contributors
+Copyright (c) 2015, Michael Stapelberg, Google Inc. and contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/make.go
+++ b/make.go
@@ -336,8 +336,8 @@ func getDebianEmail() string {
 		return email
 	}
 	mailname, err := ioutil.ReadFile("/etc/mailname")
+	// By default, /etc/mailname contains "debian" which is not useful; check for ".".
 	if err == nil && strings.Contains(string(mailname), ".") {
-		// By default, /etc/mailname contains "debian" which is not useful; check for ".".
 		if u, err := user.Current(); err == nil && u.Username != "" {
 			return u.Username + "@" + strings.TrimSpace(string(mailname))
 		}


### PR DESCRIPTION
os.user.User.Name is "" when the operating system reports it to be such.
Similarly, /dev/mailname contains just "debian" if nothing better has been set,
so I added a check for that.