### PR TITLE
Add a -git_describe_match=<version-glob> option

### DIFF
--- a/make.go
+++ b/make.go
@@ -29,6 +29,10 @@ var (
 		"",
 		"git revision (see gitrevisions(7)) of the specified Go package to check out, defaulting to the default behavior of git clone. Useful in case you do not want to package e.g. current HEAD.")
 
+	gitDescribeMatch = flag.String("git_describe_match",
+		"",
+		"The match 'glob' for use by 'git describe --match' to isolate a specific revision tag when there are other tags present. The parameter can be specified like 'v*' or v2.6' or even 'VsN2.2'.  All leading letters will be stripped from the returned version")
+
 	allowUnknownHoster = flag.Bool("allow_unknown_hoster",
 		false,
 		"The pkg-go naming conventions (see http://pkg-go.alioth.debian.org/packaging.html) use a canonical identifier for the hostname, and the mapping is hardcoded into dh-make-golang. In case you want to package a Go package living on an unknown hoster, you may set this flag to true and double-check that the resulting package name is sane. Contact pkg-go if unsure.")
@@ -131,7 +135,8 @@ func makeUpstreamSourceTarball(gopkg string) (string, string, map[string]bool, s
 
 	log.Printf("Determining upstream version number\n")
 
-	version, err := pkgVersionFromGit(filepath.Join(tempdir, "src", gopkg))
+	describeGlob := strings.TrimSpace(*gitDescribeMatch)
+	version, err := pkgVersionFromGit(filepath.Join(tempdir, "src", gopkg), describeGlob)
 	if err != nil {
 		return "", "", dependencies, autoPkgType, err
 	}

--- a/make.go
+++ b/make.go
@@ -33,6 +33,14 @@ var (
 		"",
 		"The match 'glob' for use by 'git describe --match' to isolate a specific revision tag when there are other tags present. The parameter can be specified like 'v*' or v2.6' or even 'VsN2.2'.  All leading letters will be stripped from the returned version")
 
+	forceDistribution = flag.String("force_distribution",
+		"",
+		"Forces distribution to be set as the argument instead of the default 'UNSTABLE'")
+
+	ignoreTests = flag.Bool("ignore_tests",
+		false,
+		"ignore the test dependencies and add code to debian/rules to supress test execution")
+
 	allowUnknownHoster = flag.Bool("allow_unknown_hoster",
 		false,
 		"The pkg-go naming conventions (see http://pkg-go.alioth.debian.org/packaging.html) use a canonical identifier for the hostname, and the mapping is hardcoded into dh-make-golang. In case you want to package a Go package living on an unknown hoster, you may set this flag to true and double-check that the resulting package name is sane. Contact pkg-go if unsure.")
@@ -44,7 +52,7 @@ var (
 
 // TODO: refactor this function into multiple smaller ones. Currently all the
 // code is in this function only due to the os.RemoveAll(tempdir).
-func makeUpstreamSourceTarball(gopkg string) (string, string, map[string]bool, string, error) {
+func makeUpstreamSourceTarball(gopkg string, ignoreTests bool) (string, string, map[string]bool, string, error) {
 	// dependencies is a map in order to de-duplicate multiple imports
 	// pointing into the same repository.
 	dependencies := make(map[string]bool)
@@ -178,7 +186,12 @@ func makeUpstreamSourceTarball(gopkg string) (string, string, map[string]bool, s
 
 	log.Printf("Determining dependencies\n")
 
-	cmd = exec.Command("go", "list", "-f", "{{join .Imports \"\\n\"}}\n{{join .TestImports \"\\n\"}}\n{{join .XTestImports \"\\n\"}}", gopkg+"/...")
+	importTemplate := "{{join .Imports \"\\n\"}}\n{{join .TestImports \"\\n\"}}\n{{join .XTestImports \"\\n\"}}"
+	if ignoreTests {
+		importTemplate = `{{join .Imports "\n"}}`
+	}
+
+	cmd = exec.Command("go", "list", "-f", importTemplate, gopkg+"/...")
 	cmd.Stderr = os.Stderr
 	cmd.Env = []string{
 		fmt.Sprintf("GOPATH=%s", tempdir),
@@ -374,7 +387,7 @@ func websiteForGopkg(gopkg string) string {
 	return "TODO"
 }
 
-func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies []string) error {
+func writeTemplates(dir, gopkg, debsrc, debbin, debversion, distribution string, dependencies []string, ignoreTests bool) error {
 	if err := os.Mkdir(filepath.Join(dir, "debian"), 0755); err != nil {
 		return err
 	}
@@ -388,7 +401,11 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 		return err
 	}
 	defer f.Close()
-	fmt.Fprintf(f, "%s (%s) UNRELEASED; urgency=medium\n", debsrc, debversion)
+
+	if "" == distribution {
+		distribution = "UNRELEASED"
+	}
+	fmt.Fprintf(f, "%s (%s) %s; urgency=medium\n", debsrc, debversion, distribution)
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "  * Initial release (Closes: TODO)\n")
 	fmt.Fprintf(f, "\n")
@@ -488,6 +505,10 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "%%:\n")
 	fmt.Fprintf(f, "\tdh $@ --buildsystem=golang --with=golang\n")
+	fmt.Fprintf(f, "\tdh $@ --buildsystem=golang --with=golang\n")
+	if (ignoreTests) {
+		fmt.Fprintf(f, "\noverride_dh_auto_test:\n")
+	}
 
 	f, err = os.Create(filepath.Join(dir, "debian", "source", "format"))
 	if err != nil {
@@ -650,7 +671,7 @@ func main() {
 		golangBinariesMu.Unlock()
 	}()
 
-	tempfile, version, debdependencies, autoPkgType, err := makeUpstreamSourceTarball(gopkg)
+	tempfile, version, debdependencies, autoPkgType, err := makeUpstreamSourceTarball(gopkg, *ignoreTests)
 	if err != nil {
 		log.Fatalf("Could not create a tarball of the upstream source: %v\n", err)
 	}
@@ -713,7 +734,7 @@ func main() {
 	}
 	golangBinariesMu.RUnlock()
 
-	if err := writeTemplates(dir, gopkg, debsrc, debbin, debversion, dependencies); err != nil {
+	if err := writeTemplates(dir, gopkg, debsrc, debbin, debversion, *forceDistribution, dependencies, *ignoreTests); err != nil {
 		log.Fatalf("Could not create debian/ from templates: %v\n", err)
 	}
 

--- a/make.go
+++ b/make.go
@@ -505,7 +505,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion, distribution string,
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "%%:\n")
 	fmt.Fprintf(f, "\tdh $@ --buildsystem=golang --with=golang\n")
-	fmt.Fprintf(f, "\tdh $@ --buildsystem=golang --with=golang\n")
+
 	if (ignoreTests) {
 		fmt.Fprintf(f, "\noverride_dh_auto_test:\n")
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -18,6 +18,22 @@ func gitCmdOrFatal(t *testing.T, tempdir string, arg ...string) {
 	}
 }
 
+func modifyFile(t *testing.T, tempfile string, text string) {
+	if err := ioutil.WriteFile(tempfile, []byte(text), 0644); err != nil {
+		t.Fatalf("Could not write temp file %q: %v", tempfile, err)
+	}
+}
+
+func gitCommit(t *testing.T, tempdir string, message string, timestamp string) {
+	cmd := exec.Command("git", "commit", "-a", "-m", message)
+	cmd.Env = append(os.Environ(), "GIT_COMMITTER_DATE="+timestamp)
+	cmd.Dir = tempdir
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Could not run %v: %v", cmd.Args, err)
+	}
+}
+
 func TestSnapshotVersion(t *testing.T) {
 	tempdir, err := ioutil.TempDir("", "dh-make-golang")
 	if err != nil {
@@ -26,77 +42,110 @@ func TestSnapshotVersion(t *testing.T) {
 	defer os.RemoveAll(tempdir)
 
 	tempfile := filepath.Join(tempdir, "test")
-	if err := ioutil.WriteFile(tempfile, []byte("testcase"), 0644); err != nil {
-		t.Fatalf("Could not write temp file %q: %v", tempfile, err)
-	}
+	modifyFile(t, tempfile, "testcase")
 
+	// set up the test repository
 	gitCmdOrFatal(t, tempdir, "init")
 	gitCmdOrFatal(t, tempdir, "config", "user.email", "unittest@example.com")
 	gitCmdOrFatal(t, tempdir, "config", "user.name", "Unit Test")
 	gitCmdOrFatal(t, tempdir, "add", "test")
-	cmd := exec.Command("git", "commit", "-a", "-m", "initial commit")
-	cmd.Env = append(os.Environ(), "GIT_COMMITTER_DATE=2015-04-20T11:22:33")
-	cmd.Dir = tempdir
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Could not run %v: %v", cmd.Args, err)
-	}
 
-	got, err := pkgVersionFromGit(tempdir)
-	if err != nil {
+	gitCommit(t, tempdir, "initial commit", "2015-04-20T11:22:33")
+
+	if got, err := pkgVersionFromGit(tempdir, ""); nil != err {
 		t.Fatalf("Determining package version from git failed: %v", err)
-	}
-	if want := "0.0~git20150420.0."; !strings.HasPrefix(got, want) {
-		t.Logf("got %q, want %q", got, want)
+	} else if want := "0.0~git20150420.0."; !strings.HasPrefix(got, want) {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
 	gitCmdOrFatal(t, tempdir, "tag", "-a", "v1", "-m", "release v1")
 
-	got, err = pkgVersionFromGit(tempdir)
-	if err != nil {
+	if got, err := pkgVersionFromGit(tempdir, ""); nil != err {
 		t.Fatalf("Determining package version from git failed: %v", err)
-	}
-	if want := "1"; got != want {
+	} else if want := "1"; got != want {
 		t.Logf("got %q, want %q", got, want)
 	}
 
-	if err := ioutil.WriteFile(tempfile, []byte("testcase 2"), 0644); err != nil {
-		t.Fatalf("Could not write temp file %q: %v", tempfile, err)
-	}
+	modifyFile(t, tempfile, "testcase 2")
+	gitCommit(t, tempdir, "first change", "2015-05-07T11:22:33")
 
-	cmd = exec.Command("git", "commit", "-a", "-m", "first change")
-	cmd.Env = append(os.Environ(), "GIT_COMMITTER_DATE=2015-05-07T11:22:33")
-	cmd.Dir = tempdir
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Could not run %v: %v", cmd.Args, err)
-	}
+	gitCmdOrFatal(t, tempdir, "tag", "-a", "v7.8", "-m", "release v7.8")
 
-	got, err = pkgVersionFromGit(tempdir)
-	if err != nil {
+	// check exact version
+	if got, err := pkgVersionFromGit(tempdir, ""); nil != err {
 		t.Fatalf("Determining package version from git failed: %v", err)
-	}
-	if want := "1+git20150507.1."; !strings.HasPrefix(got, want) {
-		t.Logf("got %q, want %q", got, want)
-	}
-
-	if err := ioutil.WriteFile(tempfile, []byte("testcase 3"), 0644); err != nil {
-		t.Fatalf("Could not write temp file %q: %v", tempfile, err)
+	} else if want := "7.8"; got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 
-	cmd = exec.Command("git", "commit", "-a", "-m", "second change")
-	cmd.Env = append(os.Environ(), "GIT_COMMITTER_DATE=2015-05-08T11:22:33")
-	cmd.Dir = tempdir
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Could not run %v: %v", cmd.Args, err)
-	}
+	modifyFile(t, tempfile, "testcase 3")
+	gitCommit(t, tempdir, "second change", "2015-05-08T11:22:33")
 
-	got, err = pkgVersionFromGit(tempdir)
-	if err != nil {
+	if got, err := pkgVersionFromGit(tempdir, ""); nil != err {
 		t.Fatalf("Determining package version from git failed: %v", err)
+	} else if want := "7.8+git20150508.1."; !strings.HasPrefix(got, want) {
+		t.Errorf("got %q, want %q", got, want)
 	}
-	if want := "1+git20150508.2."; !strings.HasPrefix(got, want) {
-		t.Logf("got %q, want %q", got, want)
+
+	// add a spurious tag
+	gitCmdOrFatal(t, tempdir, "tag", "-a", "foo55.55", "-m", "confusing tag")
+
+	modifyFile(t, tempfile, "testcase 4")
+	gitCommit(t, tempdir, "third change", "2015-05-09T11:22:33")
+
+	// a second spurious tag
+	gitCmdOrFatal(t, tempdir, "tag", "-a", "foo99.99", "-m", "confusing tag")
+
+	// this gets the default tag (the second spurious one)
+	if got, err := pkgVersionFromGit(tempdir, ""); nil != err {
+		t.Fatalf("Determining package version from git failed: %v", err)
+	} else if want := "foo99.99"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// this gets a specific tag
+	if got, err := pkgVersionFromGit(tempdir, "v*"); nil != err {
+		t.Fatalf("Determining package version from git failed: %v", err)
+	} else if want := "7.8-2-g"; !strings.HasPrefix(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// repeat to check that version suffix -2 -> -3
+	modifyFile(t, tempfile, "testcase 5")
+	gitCommit(t, tempdir, "fourth change", "2015-05-10T11:22:33")
+
+	if got, err := pkgVersionFromGit(tempdir, "v*"); nil != err {
+		t.Fatalf("Determining package version from git failed: %v", err)
+	} else if want := "7.8-3-g"; !strings.HasPrefix(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// repeat check wth exact version number
+	if got, err := pkgVersionFromGit(tempdir, "v7.8"); nil != err {
+		t.Fatalf("Determining package version from git failed: %v", err)
+	} else if want := "7.8-3-g"; !strings.HasPrefix(got, want) {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// try a strange version tag
+	modifyFile(t, tempfile, "testcase 6")
+	gitCommit(t, tempdir, "fifth change", "2015-05-10T12:22:33")
+
+	gitCmdOrFatal(t, tempdir, "tag", "-a", "VrSn67.12", "-m", "strange version tag")
+
+	if got, err := pkgVersionFromGit(tempdir, "VrSn*"); nil != err {
+		t.Fatalf("Determining package version from git failed: %v", err)
+	} else if want := "67.12"; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+
+	// check that strange version gets the -N-g* suffix after a change
+	modifyFile(t, tempfile, "testcase 7")
+	gitCommit(t, tempdir, "sixth change", "2015-05-11T12:22:33")
+
+	if got, err := pkgVersionFromGit(tempdir, "VrSn*"); nil != err {
+		t.Fatalf("Determining package version from git failed: %v", err)
+	} else if want := "67.12-1-g"; !strings.HasPrefix(got, want) {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
This is to manually override the version detection when the normal
detection returns the wrong tag.  Also to provide a mechanism for
alphabetic prefix stripping where the prefix if no just a lower case 'v'.

examples.
~~~
  -git_describe_match=v2.5
  -git_describe_match='v*'
  -git_describe_match=V22
  -git_describe_match='VrSn*'
~~~

Signed-off-by: Christopher Hall <hsw@ms2.hinet.net>