### PR TITLE
Add a new -git_describe_match=GLOB option

### DIFF
--- a/make.go
+++ b/make.go
@@ -29,6 +29,10 @@ var (
 		"",
 		"git revision (see gitrevisions(7)) of the specified Go package to check out, defaulting to the default behavior of git clone. Useful in case you do not want to package e.g. current HEAD.")
 
+	gitDescribeMatch = flag.String("git_describe_match",
+		"",
+		"The match 'glob' for use by 'git describe --match' to isolate a specific revision tag when there are other tags present. The parameter can be specified like '*' '2.6' '2.*' or even '19.*.24'.  This assumes git version tags are prefixed with 'v' (which is always stripped)")
+
 	allowUnknownHoster = flag.Bool("allow_unknown_hoster",
 		false,
 		"The pkg-go naming conventions (see http://pkg-go.alioth.debian.org/packaging.html) use a canonical identifier for the hostname, and the mapping is hardcoded into dh-make-golang. In case you want to package a Go package living on an unknown hoster, you may set this flag to true and double-check that the resulting package name is sane. Contact pkg-go if unsure.")
@@ -131,7 +135,9 @@ func makeUpstreamSourceTarball(gopkg string) (string, string, map[string]bool, s
 
 	log.Printf("Determining upstream version number\n")
 
-	version, err := pkgVersionFromGit(filepath.Join(tempdir, "src", gopkg))
+	describeGlob := strings.TrimSpace(*gitDescribeMatch)
+	version, err := pkgVersionFromGit(filepath.Join(tempdir, "src", gopkg), describeGlob)
+
 	if err != nil {
 		return "", "", dependencies, autoPkgType, err
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -42,7 +42,7 @@ func TestSnapshotVersion(t *testing.T) {
 		t.Fatalf("Could not run %v: %v", cmd.Args, err)
 	}
 
-	got, err := pkgVersionFromGit(tempdir)
+	got, err := pkgVersionFromGit(tempdir, "")
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestSnapshotVersion(t *testing.T) {
 
 	gitCmdOrFatal(t, tempdir, "tag", "-a", "v1", "-m", "release v1")
 
-	got, err = pkgVersionFromGit(tempdir)
+	got, err = pkgVersionFromGit(tempdir, "")
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestSnapshotVersion(t *testing.T) {
 		t.Fatalf("Could not run %v: %v", cmd.Args, err)
 	}
 
-	got, err = pkgVersionFromGit(tempdir)
+	got, err = pkgVersionFromGit(tempdir, "")
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}
@@ -92,11 +92,51 @@ func TestSnapshotVersion(t *testing.T) {
 		t.Fatalf("Could not run %v: %v", cmd.Args, err)
 	}
 
-	got, err = pkgVersionFromGit(tempdir)
+	got, err = pkgVersionFromGit(tempdir, "")
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}
 	if want := "1+git20150508.2."; !strings.HasPrefix(got, want) {
 		t.Logf("got %q, want %q", got, want)
+	}
+
+	// test the describe match glob
+
+	gitCmdOrFatal(t, tempdir, "tag", "-a", "v2.7", "-m", "new version tag")
+
+	if err := ioutil.WriteFile(tempfile, []byte("testcase 4"), 0644); err != nil {
+		t.Fatalf("Could not write temp file %q: %v", tempfile, err)
+	}
+
+	cmd = exec.Command("git", "commit", "-a", "-m", "third change")
+	cmd.Env = append(os.Environ(), "GIT_COMMITTER_DATE=2015-05-09T11:22:33")
+	cmd.Dir = tempdir
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Could not run %v: %v", cmd.Args, err)
+	}
+
+	gitCmdOrFatal(t, tempdir, "tag", "-a", "xyz99.99", "-m", "spurious tag")
+
+	if err := ioutil.WriteFile(tempfile, []byte("testcase 5"), 0644); err != nil {
+		t.Fatalf("Could not write temp file %q: %v", tempfile, err)
+	}
+
+	cmd = exec.Command("git", "commit", "-a", "-m", "fourth change")
+	cmd.Env = append(os.Environ(), "GIT_COMMITTER_DATE=2015-05-09T11:22:33")
+	cmd.Dir = tempdir
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Could not run %v: %v", cmd.Args, err)
+	}
+
+	for _, versionGlob := range []string{"*", "v*", "2.*", "v2.*", "2.7", "v2.7"} {
+		got, err = pkgVersionFromGit(tempdir, versionGlob)
+		if err != nil {
+			t.Fatalf("Determining package version from git failed: %v", err)
+		}
+		if want := "2.7-2-g"; !strings.HasPrefix(got, want) {
+			t.Logf("got %q, want %q", got, want)
+		}
 	}
 }


### PR DESCRIPTION
The features are:
* allows for skipping non-version tags
* assumes version tags are 'v' prefixed and are N, N.N  or N.N....N
  (where N represents a decimal number
* the argument is a glob to match with a '*' to represent the wildcard
* example globs: '*' '2.*' '19.*.5'
* the 'v' is optional in the GLOB i.e. this is ok:  `-git_describe_match='v8.*'`
  and has the same meaning as: `-git_describe_match='8.*'`