### PR TITLE
Allow the use of gccgo on architectures without golang-go

### DIFF
--- a/make.go
+++ b/make.go
@@ -432,7 +432,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 	fmt.Fprintf(f, "Maintainer: Debian Go Packaging Team <pkg-go-maintainers@lists.alioth.debian.org>\n")
 	fmt.Fprintf(f, "Uploaders: %s <%s>\n", getDebianName(), getDebianEmail())
 	sort.Strings(dependencies)
-	builddeps := append([]string{"debhelper (>= 9)", "dh-golang", "golang-go"}, dependencies...)
+	builddeps := append([]string{"debhelper (>= 9)", "dh-golang", "golang-any"}, dependencies...)
 	fmt.Fprintf(f, "Build-Depends: %s\n", strings.Join(builddeps, ",\n               "))
 	fmt.Fprintf(f, "Standards-Version: 3.9.8\n")
 	fmt.Fprintf(f, "Homepage: %s\n", websiteForGopkg(gopkg))
@@ -447,7 +447,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 		fmt.Fprintf(f, "Built-Using: ${misc:Built-Using}\n")
 	} else {
 		fmt.Fprintf(f, "Architecture: all\n")
-		deps = append(append(deps, "golang-go"), dependencies...)
+		deps = append(deps, dependencies...)
 	}
 	fmt.Fprintf(f, "Depends: %s\n", strings.Join(deps, ",\n         "))
 	description, err := getDescriptionForGopkg(gopkg)


### PR DESCRIPTION
* Build-Depends on gccgo where golang-go is not available
  i.e., [!amd64 !arm64 !armel !armhf !i386 !ppc64 !ppc64el]

* Remove Depends on golang-go

----

When the debian/control file of a Go program and its dependencies have this change made, this allows the Go program to be built on more platforms, especially powerpc, sparc64, s390x, mips and mipsel, and hopefully more.

For example, see https://buildd.debian.org/status/package.php?p=go-md2man for the current build status of go-md2man.  Of course, my own personal goal is to have [Hugo](https://buildd.debian.org/status/package.php?p=hugo) available on as many platforms as possible.  :wink:

Many thanks!