### PR TITLE
Bump Standards-Version to 3.9.8

### DIFF
--- a/make.go
+++ b/make.go
@@ -434,7 +434,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 	sort.Strings(dependencies)
 	builddeps := append([]string{"debhelper (>= 9)", "dh-golang", "golang-go"}, dependencies...)
 	fmt.Fprintf(f, "Build-Depends: %s\n", strings.Join(builddeps, ",\n               "))
-	fmt.Fprintf(f, "Standards-Version: 3.9.7\n")
+	fmt.Fprintf(f, "Standards-Version: 3.9.8\n")
 	fmt.Fprintf(f, "Homepage: %s\n", websiteForGopkg(gopkg))
 	fmt.Fprintf(f, "Vcs-Browser: https://anonscm.debian.org/cgit/pkg-go/packages/%s.git\n", debsrc)
 	fmt.Fprintf(f, "Vcs-Git: https://anonscm.debian.org/git/pkg-go/packages/%s.git\n", debsrc)


### PR DESCRIPTION
The new Debian Policy version 3.9.8.0 came out on 2016-03-30
and entered the Debian archive on 2016-04-06.