### PR TITLE
Replace "_" with "-" in program name

### DIFF
--- a/make_test.go
+++ b/make_test.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"testing"
+)
+
+var shortName = []struct {
+	in  string
+	out string
+}{
+	{"", "TODO"},
+	{"d", "TODO"},
+	{"d--", "TODO"},
+}
+
+func TestAcceptInput(t *testing.T) {
+	for _, tt := range shortName {
+		in := normalizeDebianProgramName(tt.in)
+		if in != tt.out {
+			t.Errorf("userInput(%q) => %q, want %q", tt.in, tt.out)
+		}
+	}
+}
+
+var miscName = []struct {
+	in  string
+	out string
+}{
+	{"dh-make-golang", "dh-make-golang"},
+	{"DH-make-golang", "dh-make-golang"},
+	{"dh_make_golang", "dh-make-golang"},
+	{"dh_make*go&3*@@", "dh-makego3"},
+	{"7h_make*go&3*@@", "7h-makego3"},
+	{"7h_make*go&3*.@", "7h-makego3."},
+	{"7h_make*go+3*.@", "7h-makego+3."},
+}
+
+func TestNormalizeDebianProgramName(t *testing.T) {
+	for _, tt := range miscName {
+		s := normalizeDebianProgramName(tt.in)
+		if s != tt.out {
+			t.Errorf("normalizeDebianProgramName(%q) => %q, want %q", tt.in, tt.out)
+		}
+	}
+}
+
+var nameFromGoPkg = []struct {
+	in  string
+	t   string
+	out string
+}{
+	{"github.com/dh-make-golang", "program", "dh-make-golang"},
+	{"github.com/DH-make-golang", "", "golang-github-dh-make-golang"},
+	{"github.com/dh_make_golang", "", "golang-github-dh-make-golang"},
+}
+
+func TestDebianNameFromGopkg(t *testing.T) {
+	for _, tt := range nameFromGoPkg {
+		s := debianNameFromGopkg(tt.in, tt.t)
+		if s != tt.out {
+			t.Errorf("debianNameFromGopkg(%q) => %q, want %q", tt.in, s, tt.out)
+		}
+	}
+}


### PR DESCRIPTION
This is to ensure it follow Debian Maintainer Guide in regard to
[package](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Source) name

Issue appeared when trying to build a repo with `_`.

```
root@cb38face0702:~# ./bin/dh-make-golang github.com/bitly/oauth2_proxy
2016/09/12 23:07:22 Downloading "github.com/bitly/oauth2_proxy/..."
2016/09/12 23:07:49 Determining upstream version number
2016/09/12 23:07:49 WARNING: Lightweight tag "v2.1" found, but the most recent annotated tag is "v0.1"
2016/09/12 23:07:49     Lightweight tags (created by e.g. "git tag v2.1"
2016/09/12 23:07:49     with no flag) are problematic because, among other
2016/09/12 23:07:49     things, they are ignored by "git describe" by default.
2016/09/12 23:07:49     Please suggest that the upstream replaces the
2016/09/12 23:07:49     lightweight tags with annotated ones.  See
2016/09/12 23:07:49     https://github.com/russross/blackfriday/issues/196
2016/09/12 23:07:49     for details.
2016/09/12 23:07:49
2016/09/12 23:07:49 Package version is "2.1+git20160825.15.a9c55bd"
2016/09/12 23:07:49 Determining package type
2016/09/12 23:07:49 Assuming you are packaging a program (because "github.com/bitly/oauth2_proxy" defines a main package), use -type to override
2016/09/12 23:07:49 Determining dependencies
gbp:error: Couldn't determine upstream package name. Use --interactive.
2016/09/12 23:07:51 Could not create git repository: exit status 1
```