### PR TITLE
Fix watch file format

### DIFF
--- a/make.go
+++ b/make.go
@@ -564,8 +564,8 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 		}
 		defer f.Close()
 		fmt.Fprintf(f, "version=3\n")
-		fmt.Fprintf(f, `opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/%s-\$1\.tar\.gz/,\\`+"\n", debsrc)
-		fmt.Fprintf(f, `uversionmangle=s/(\d)[_\.\-\+]?(RC|rc|pre|dev|beta|alpha)[.]?(\d*)$/\$1~\$2\$3/ \\`+"\n")
+		fmt.Fprintf(f, `opts=filenamemangle=s/.+\/v?(\d\S*)\.tar\.gz/%s-\$1\.tar\.gz/,\`+"\n", debsrc)
+		fmt.Fprintf(f, `uversionmangle=s/(\d)[_\.\-\+]?(RC|rc|pre|dev|beta|alpha)[.]?(\d*)$/\$1~\$2\$3/ \`+"\n")
 		fmt.Fprintf(f, `  https://%s/tags .*/v?(\d\S*)\.tar\.gz`+"\n", gopkg)
 	}
 


### PR DESCRIPTION
The debian watch file should only contain one backslash at the end
of the lines (to escape the new lines)
Fixes #53