### PR TITLE
Add compatibility with go1.2.1

### DIFF
--- a/make.go
+++ b/make.go
@@ -51,7 +51,8 @@ func passthroughEnv() []string {
 	}
 	var result []string
 	for _, variable := range relevantVariables {
-		if value, ok := os.LookupEnv(variable); ok {
+		value := os.Getenv(variable);
+		if (value != "") {
 			result = append(result, fmt.Sprintf("%s=%s", variable, value))
 		}
 	}


### PR DESCRIPTION
os.Getenv is available in older versions of Golang. This change allows dh-make-golang to be built using go1.2.1, as distributed in Ubuntu 14.04.