### PR TITLE
Add autopkgtest support by default

### DIFF
--- a/make.go
+++ b/make.go
@@ -493,6 +493,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 	fmt.Fprintf(f, "Vcs-Browser: https://anonscm.debian.org/cgit/pkg-go/packages/%s.git\n", debsrc)
 	fmt.Fprintf(f, "Vcs-Git: https://anonscm.debian.org/git/pkg-go/packages/%s.git\n", debsrc)
 	fmt.Fprintf(f, "XS-Go-Import-Path: %s\n", gopkg)
+	fmt.Fprintf(f, "Testsuite: autopkgtest-pkg-go\n")
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "Package: %s\n", debbin)
 	deps := []string{"${shlibs:Depends}", "${misc:Depends}"}


### PR DESCRIPTION
This is a patch by Martín Ferrari (<tincho@d.o>) which I'm forwarding. I've already applied it in the latest upload of dh-make-golang for Debian.