### PR TITLE
Add a default "Files-Excluded" value for uscan's sake

### DIFF
--- a/make.go
+++ b/make.go
@@ -537,6 +537,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion string, dependencies 
 	fmt.Fprintf(f, "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n")
 	fmt.Fprintf(f, "Upstream-Name: %s\n", filepath.Base(gopkg))
 	fmt.Fprintf(f, "Source: %s\n", websiteForGopkg(gopkg))
+	fmt.Fprintf(f, "Files-Excluded: vendor Godeps/_workspace\n")
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "Files: *\n")
 	fmt.Fprintf(f, "Copyright: %s\n", copyright)


### PR DESCRIPTION
Similar to the `debian/watch` we generate, it seems it'd be useful to also include `Files-Excluded` by default for if/when upstreams switch over to versioned releases which then get consumed via `uscan` instead of via `dh-make-golang`.

Happy to adjust, rebase, amend, discuss, etc. :+1: