### PR TITLE
Add howett.net as a known host

### DIFF
--- a/make.go
+++ b/make.go
@@ -397,6 +397,8 @@ func debianNameFromGopkg(gopkg, t string) string {
 		host = "bazil"
 	} else if host == "pault.ag" {
 		host = "pault"
+	} else if host == "howett.net" {
+		host = "howett"
 	} else {
 		if *allowUnknownHoster {
 			suffix, _ := publicsuffix.PublicSuffix(host)


### PR DESCRIPTION
Hi! I'm tracking an issue at DHowett/go-plist#22 where a user has reported that `howett.net/plist` is not an acceptable import path to `dh-make-golang`.

_Aside:_ I'm not certain about the long-term viability of a flat list of vanity import paths. Perhaps there's a solution that allows for Debian to confidently and safely package arbitrary Go packages without being too infrastructure- or process-taxing. What do you think?