### PR TITLE
support comma-separated paths in Go-Import-Path

### DIFF
--- a/search.go
+++ b/search.go
@@ -26,9 +26,9 @@ func getGolangBinaries() (map[string]string, error) {
 		return nil, fmt.Errorf("unexpected HTTP status code: got %d, want %d", got, want)
 	}
 	var pkgs []struct {
-		Binary     string `json:"binary"`
-		ImportPath string `json:"metadata_value"`
-		Source     string `json:"source"`
+		Binary         string `json:"binary"`
+		XSGoImportPath string `json:"metadata_value"`
+		Source         string `json:"source"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&pkgs); err != nil {
 		return nil, err
@@ -37,7 +37,10 @@ func getGolangBinaries() (map[string]string, error) {
 		if !strings.HasSuffix(pkg.Binary, "-dev") {
 			continue // skip -dbgsym packages etc.
 		}
-		golangBinaries[pkg.ImportPath] = pkg.Binary
+		for _, importPath := range strings.Split(pkg.XSGoImportPath, ",") {
+			// XS-Go-Import-Path can be comma-separated and contain spaces.
+			golangBinaries[strings.TrimSpace(importPath)] = pkg.Binary
+		}
 	}
 	return golangBinaries, nil
 }


### PR DESCRIPTION
Closes #74

See my commit message for details:
````
Some packages can be imported from several import paths.
XS-Go-Import-Path can reflect this by using a comma-separated list
of known import paths for the package.

This patch updates make.go's existing package detection mechanism to
support this.

The pkgs struct field ImportPath is renamed to XSGoImportPath to avoid
confusion because it could be that XSGoImportPath is not a valid import
path if it contains commas.

For example, the following format would now be valid:
```
XS-Go-Import-Path: github.com/go-mgo/mgo,
                   gopkg.in/mgo.v2,
                   labix.org/v2/mgo,
                   launchpad.net/mgo
```
````

I have tested api.ftp-master.debian.org and confirmed that the API's ``metadata_value`` field does not contain newlines.

We can merge this right now, but we would also need to update dh-golang before it can be usable:

For dh-golang, my suggestion would be to use the first path and ignore the others:
```perl
# lib/Debian/Debhelper/Buildsystem/golang.pm (line 242)
$ENV{DH_GOPKG} = (split ",", $source->{"XS-Go-Import-Path"})[0];
```