### PR TITLE
create search command

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"flag"
+	"os"
+)
+
+func main() {
+	// Retrieve args and Shift binary name off argument list.
+	args := os.Args[1:]
+
+	fs := flag.NewFlagSet("main", flag.ExitOnError)
+	fs.Parse(args)
+
+	// Retrieve command name as first argument.
+	cmd := fs.Arg(0)
+
+	switch cmd {
+	case "search":
+		execSearch(args[1:])
+	default:
+		execMake(args)
+	}
+
+}

--- a/search.go
+++ b/search.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+)
+
+const (
+	golangBinariesURL = "https://api.ftp-master.debian.org/binary/by_metadata/Go-Import-Path"
+)
+
+func getGolangBinaries() (map[string]string, error) {
+	golangBinaries := make(map[string]string)
+
+	resp, err := http.Get(golangBinariesURL)
+	if err != nil {
+		return nil, fmt.Errorf("getting %q: %v", golangBinariesURL)
+	}
+	if got, want := resp.StatusCode, http.StatusOK; got != want {
+		return nil, fmt.Errorf("unexpected HTTP status code: got %d, want %d", got, want)
+	}
+	var pkgs []struct {
+		Binary     string `json:"binary"`
+		ImportPath string `json:"metadata_value"`
+		Source     string `json:"source"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&pkgs); err != nil {
+		return nil, err
+	}
+	for _, pkg := range pkgs {
+		if !strings.HasSuffix(pkg.Binary, "-dev") {
+			continue // skip -dbgsym packages etc.
+		}
+		golangBinaries[pkg.ImportPath] = pkg.Binary
+	}
+	return golangBinaries, nil
+}
+
+func execSearch(args []string) {
+	fs := flag.NewFlagSet("search", flag.ExitOnError)
+
+	err := fs.Parse(args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if fs.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "Usage: %s search <pattern>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Uses Go's default regexp syntax (https://golang.org/pkg/regexp/syntax/)\n")
+		fmt.Fprintf(os.Stderr, "Example: %s search debi.*\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	pattern, err := regexp.Compile(fs.Arg(0))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	golangBinaries, err := getGolangBinaries()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for importPath, binary := range golangBinaries {
+		if pattern.MatchString(importPath) {
+			fmt.Printf("%s: %s\n", binary, importPath)
+		}
+	}
+}


### PR DESCRIPTION
Closes: #76

Note that this PR does **not** include #75. Feel free to merge them separately, in any order. I will also gladly rebase one on the other if needed.

see my commit message for details:

````
Example usage:
```
    $ dh-make-golang search debian
    golang-godebiancontrol-dev: github.com/stapelberg/godebiancontrol
    golang-pault-go-debian-dev: pault.ag/go/debian
```

Example use case: I imported a new upstream version for my existing
package and it won't build anymore because of a new dependency. I run
``dh-make-golang search <keyword>`` to quickly find the Debian binary
package name and add it to the build dependencies.
````

I know that dh-make-golang warns when packaging stuff that is already packaged but I would find this very useful for searching what is already available in Debian.