### PR TITLE
main: don't use flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"os"
 )
 
@@ -9,11 +8,11 @@ func main() {
 	// Retrieve args and Shift binary name off argument list.
 	args := os.Args[1:]
 
-	fs := flag.NewFlagSet("main", flag.ExitOnError)
-	fs.Parse(args)
-
 	// Retrieve command name as first argument.
-	cmd := fs.Arg(0)
+	cmd := ""
+	if len(args) > 0 {
+		cmd = args[0]
+	}
 
 	switch cmd {
 	case "search":


### PR DESCRIPTION
Using dh-make-golang with flags (which are the arguments) no longer works.

For example: ``dh-make-golang -type library <importpath>`` will output "unknown flag: -type".

flagsets can be configured with ``ContinueOnError`` or ``ExitOnError``. However, it will still output the error message.

In our case, we don't use any of the flagset feature anyways, so I simply removed it.
 
  
  