### PR TITLE
Update make.go - Changing the standards version

### DIFF
--- a/make.go
+++ b/make.go
@@ -475,7 +475,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion, pkgType string, depe
 	sort.Strings(dependencies)
 	builddeps := append([]string{"debhelper (>= 10)", "dh-golang", "golang-any"}, dependencies...)
 	fmt.Fprintf(f, "Build-Depends: %s\n", strings.Join(builddeps, ",\n               "))
-	fmt.Fprintf(f, "Standards-Version: 4.1.1\n")
+	fmt.Fprintf(f, "Standards-Version: 4.1.3\n")
 	fmt.Fprintf(f, "Homepage: %s\n", getHomepageForGopkg(gopkg))
 	fmt.Fprintf(f, "Vcs-Browser: https://anonscm.debian.org/cgit/pkg-go/packages/%s.git\n", debsrc)
 	fmt.Fprintf(f, "Vcs-Git: https://anonscm.debian.org/git/pkg-go/packages/%s.git\n", debsrc)


### PR DESCRIPTION
Updating the standards version to follow the latest as per the latest standards version of Debian policy. 
`4.1.3`