### PR TITLE
Remove shlibs:Depends from library packages

### DIFF
--- a/make.go
+++ b/make.go
@@ -502,10 +502,11 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion, pkgType string, depe
 	fmt.Fprintf(f, "Testsuite: autopkgtest-pkg-go\n")
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "Package: %s\n", debbin)
-	deps := []string{"${shlibs:Depends}", "${misc:Depends}"}
+	deps := []string{"${misc:Depends}"}
 	if pkgType == "program" {
 		fmt.Fprintf(f, "Architecture: any\n")
 		fmt.Fprintf(f, "Built-Using: ${misc:Built-Using}\n")
+		deps = append(deps, "${shlibs:Depends}")
 	} else {
 		fmt.Fprintf(f, "Architecture: all\n")
 		deps = append(deps, dependencies...)


### PR DESCRIPTION
Currently, `dh-make-golang` automatically adds `${shlibs:Depends}` in the `Depends` field of the library package. However when building the package, it leads to this warning:

    unknown substitution variable ${shlibs:Depends}

So it looks like field `${shlibs:Depends}` shouldn't be there.