### PR TITLE
use  team+pkg-go@tracker.debian.org in Maintainer

### DIFF
--- a/make.go
+++ b/make.go
@@ -491,7 +491,7 @@ func writeTemplates(dir, gopkg, debsrc, debbin, debversion, pkgType string, depe
 	// TODO: change this once we have a “golang” section.
 	fmt.Fprintf(f, "Section: devel\n")
 	fmt.Fprintf(f, "Priority: optional\n")
-	fmt.Fprintf(f, "Maintainer: Debian Go Packaging Team <pkg-go-maintainers@lists.alioth.debian.org>\n")
+	fmt.Fprintf(f, "Maintainer: Debian Go Packaging Team <team+pkg-go@tracker.debian.org>\n")
 	fmt.Fprintf(f, "Uploaders: %s <%s>\n", getDebianName(), getDebianEmail())
 	sort.Strings(dependencies)
 	builddeps := append([]string{"debhelper (>= 11)", "dh-golang", "golang-any"}, dependencies...)


### PR DESCRIPTION
According to
 - https://wiki.debian.org/Salsa/AliothMigration#tracker.debian.org
 - https://qa.pages.debian.net/distro-tracker/usage/teams.html#team-email-address

this is the email that we should use for the team at https://tracker.debian.org/teams/pkg-go/.

> This email address can also be used in the Maintainer field of Debian packages. By doing this, you ensure that your team’s packages are automatically added to the Distro Tracker team and that all members get the associated messages.

Users can modify emails that they want to receive for the team at https://tracker.debian.org/accounts/subscriptions/ with the Modify Keyword button.