### PR TITLE
Patch: Fixes #120

### DIFF
--- a/make.go
+++ b/make.go
@@ -543,7 +543,7 @@ func shortHostName(gopkg string, allowUnknownHoster bool) (host string, err erro
 	default:
 		if allowUnknownHoster {
 			suffix, _ := publicsuffix.PublicSuffix(host)
-			host = host[:len(host)-len(suffix)-len(".")]
+			host = fqdn[:len(fqdn)-len(suffix)-len(".")]
 			log.Printf("WARNING: Using %q as canonical hostname for %q. If that is not okay, please file a bug against %s.\n", host, fqdn, os.Args[0])
 		} else {
 			err = fmt.Errorf("unknown hoster %q", fqdn)


### PR DESCRIPTION
Package: dh-make-golang
Version: 0.3.0-1

**Background**
When invoking 'dh-make-golang' with -allow_unknown_hoster argument the 
user experiences 'panic: runtime error: slice bounds out of range [:-1]' 
This is due to the host variable being unassigned prior to slicing.

**Output**
`panic: runtime error: slice bounds out of range [:-1]`

**Reproduce**
`dh-make-golang make -allow_unknown_hoster code.cloudfoundry.org/bytefmt`

Fixes #120 

**Debian Bug** 
947512

Cheers, 

James
