### PR TITLE
Add sourcehut (git.sr.ht) to knownHosts

### DIFF
--- a/make.go
+++ b/make.go
@@ -547,6 +547,7 @@ func shortHostName(gopkg string, allowUnknownHoster bool) (host string, err erro
 		"blitiri.com.ar":    "blitiri",
 		"cloud.google.com":  "googlecloud",
 		"code.google.com":   "googlecode",
+		"git.sr.ht":         "sourcehut",
 		"github.com":        "github",
 		"gitlab.com":        "gitlab",
 		"go4.org":           "go4",


### PR DESCRIPTION
In the interest of packaging [aerc](https://aerc-mail.org) ([ITP](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=947962#5)), I think it is prudent to add git.sr.ht as known host for Go packages.

I have no idea how `go get` works internally, maybe it would make more sense to add each sourcehut VCS with it's VCS name (git-sourcehut or sourcehut-git), since it will prevent conflicts in the future. Any input is greatly appreciated. 