### PR TITLE
Manage MIT (Expat) license

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -26,8 +26,8 @@ var githubLicenseToDebianLicense = map[string]string{
 	"isc":      "ISC",
 	"lgpl-2.1": "LGPL-2.1",
 	"lgpl-3.0": "LGPL-3.0",
-	//"mit" - expat?
-	"mpl-2.0": "MPL-2.0", // include in base-files >= 9.9
+	"mit":      "Expat",
+	"mpl-2.0":  "MPL-2.0", // include in base-files >= 9.9
 	//"unlicense" (not in debian)
 }
 


### PR DESCRIPTION
Hello there!

I have used your tool to package some libraries, and I have noticed that the MIT license was not recognized.

As you can view on the [MIT wikipedia page](https://en.wikipedia.org/wiki/MIT_License#Variants), "MIT License" may refer to the Expat License (used for the XML parsing library Expat). It was an historical naming.

I don't know if it's needed, but I have submitted a bug on BTS, available [here](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=951304).

Thank your for the wonderful tool by the way ! 👍 

Have a good day.