### PR TITLE
Annotate errors before returning them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dh-make-golang
 _build/
+*~
+*.sw[op]

--- a/create_salsa_project.go
+++ b/create_salsa_project.go
@@ -19,7 +19,7 @@ func execCreateSalsaProject(args []string) {
 	}
 
 	if err := fs.Parse(args); err != nil {
-		log.Fatal(err)
+		log.Fatalf("parse: %s", err)
 	}
 
 	if fs.NArg() != 1 {
@@ -38,7 +38,7 @@ func execCreateSalsaProject(args []string) {
 
 	resp, err := http.Post(u.String(), "", nil)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("http post: %s", err)
 	}
 	if got, want := resp.StatusCode, http.StatusOK; got != want {
 		b, _ := ioutil.ReadAll(resp.Body)

--- a/description.go
+++ b/description.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os/exec"
 	"strings"
 
@@ -22,17 +23,17 @@ func reformatForControl(raw string) string {
 func getLongDescriptionForGopkg(gopkg string) (string, error) {
 	owner, repo, err := findGitHubRepo(gopkg)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("find github repo: %w", err)
 	}
 
 	rr, _, err := gitHub.Repositories.GetReadme(context.TODO(), owner, repo, nil)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get readme: %w", err)
 	}
 
 	content, err := rr.GetContent()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get content: %w", err)
 	}
 
 	// Supported filename suffixes are from
@@ -55,7 +56,7 @@ func getLongDescriptionForGopkg(gopkg string) (string, error) {
 	cmd.Stdin = bytes.NewBuffer(output)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("fmt: %w", err)
 	}
 	return reformatForControl(strings.TrimSpace(string(out))), nil
 }

--- a/estimate.go
+++ b/estimate.go
@@ -49,34 +49,34 @@ func removeVendor(gopath string) (found bool, _ error) {
 		}
 		found = true
 		if err := os.RemoveAll(path); err != nil {
-			return err
+			return fmt.Errorf("remove all: %w", err)
 		}
 		return filepath.SkipDir
 	})
-	return found, err
+	return found, fmt.Errorf("walk: %w", err)
 }
 
 func estimate(importpath string) error {
 	// construct a separate GOPATH in a temporary directory
 	gopath, err := ioutil.TempDir("", "dh-make-golang")
 	if err != nil {
-		return err
+		return fmt.Errorf("create temp dir: %w", err)
 	}
 	defer os.RemoveAll(gopath)
 
 	if err := get(gopath, importpath); err != nil {
-		return err
+		return fmt.Errorf("go get: %w", err)
 	}
 
 	found, err := removeVendor(gopath)
 	if err != nil {
-		return err
+		return fmt.Errorf("remove vendor: %w", err)
 	}
 
 	if found {
 		// Fetch un-vendored dependencies
 		if err := get(gopath, importpath); err != nil {
-			return err
+			return fmt.Errorf("fetch un-vendored: go get: %w", err)
 		}
 	}
 
@@ -89,7 +89,7 @@ func estimate(importpath string) error {
 
 	out, err := cmd.Output()
 	if err != nil {
-		return fmt.Errorf("%v: %v", cmd.Args, err)
+		return fmt.Errorf("go list std: args: %v; error: %w", cmd.Args, err)
 	}
 	stdlib := make(map[string]bool)
 	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
@@ -185,7 +185,7 @@ func execEstimate(args []string) {
 
 	err := fs.Parse(args)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("parse args: %s", err)
 	}
 
 	if fs.NArg() != 1 {
@@ -196,6 +196,6 @@ func execEstimate(args []string) {
 	// TODO: support the -git_revision flag
 
 	if err := estimate(fs.Arg(0)); err != nil {
-		log.Fatal(err)
+		log.Fatalf("estimate: %s", err)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/mattn/go-isatty v0.0.10
 	github.com/russross/blackfriday v1.5.2
+	golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 // indirect
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/tools v0.0.0-20190731163215-a81e99d7481f

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-github/v32 v32.1.0 h1:GWkQOdXqviCPx7Q7Fj+KyPoGm4SwHRh8rheoPhd27II=
 github.com/google/go-github/v32 v32.1.0/go.mod h1:rIEpZD9CTDQwDK9GDrtMTycQNA4JU3qBsCizh3q2WCI=
@@ -11,7 +12,10 @@ github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNue
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59 h1:3zb4D3T4G8jdExgVU/95+vQXfpEPiMdCaZgmGVxjNHM=
+golang.org/x/crypto v0.0.0-20200323165209-0ec3e9974c59/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 h1:Ao/3l156eZf2AW5wK8a7/smtodRU+gha3+BeqJ69lRk=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -19,6 +23,7 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be h1:QAcqgptGM8IQBC9K/RC4o+O9YmqEm0diQn9QmZw/0mU=
 golang.org/x/sys v0.0.0-20191008105621-543471e840be/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/metadata.go
+++ b/metadata.go
@@ -64,7 +64,7 @@ func findGitHubOwnerRepo(gopkg string) (string, error) {
 	}
 	resp, err := http.Get("https://" + gopkg + "?go-get=1")
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("HTTP get: %w", err)
 	}
 	defer resp.Body.Close()
 	z := html.NewTokenizer(resp.Body)
@@ -112,7 +112,7 @@ func findGitHubOwnerRepo(gopkg string) (string, error) {
 func findGitHubRepo(gopkg string) (owner string, repo string, _ error) {
 	ownerrepo, err := findGitHubOwnerRepo(gopkg)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("find GitHub owner repo: %w", err)
 	}
 	parts := strings.Split(ownerrepo, "/")
 	if got, want := len(parts), 2; got != want {
@@ -124,12 +124,12 @@ func findGitHubRepo(gopkg string) (owner string, repo string, _ error) {
 func getLicenseForGopkg(gopkg string) (string, string, error) {
 	owner, repo, err := findGitHubRepo(gopkg)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("find GitHub repo: %w", err)
 	}
 
 	rl, _, err := gitHub.Repositories.License(context.TODO(), owner, repo)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("get license for Go package: %w", err)
 	}
 
 	if deblicense, ok := githubLicenseToDebianLicense[rl.GetLicense().GetKey()]; ok {
@@ -146,12 +146,12 @@ func getLicenseForGopkg(gopkg string) (string, string, error) {
 func getAuthorAndCopyrightForGopkg(gopkg string) (string, string, error) {
 	owner, repo, err := findGitHubRepo(gopkg)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("find GitHub repo: %w", err)
 	}
 
 	rr, _, err := gitHub.Repositories.Get(context.TODO(), owner, repo)
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("get repo: %w", err)
 	}
 
 	if strings.TrimSpace(rr.GetOwner().GetURL()) == "" {
@@ -160,7 +160,7 @@ func getAuthorAndCopyrightForGopkg(gopkg string) (string, string, error) {
 
 	ur, _, err := gitHub.Users.Get(context.TODO(), rr.GetOwner().GetLogin())
 	if err != nil {
-		return "", "", err
+		return "", "", fmt.Errorf("get user: %w", err)
 	}
 
 	copyright := rr.CreatedAt.Format("2006") + " " + ur.GetName()
@@ -178,7 +178,7 @@ func getAuthorAndCopyrightForGopkg(gopkg string) (string, string, error) {
 func getDescriptionForGopkg(gopkg string) (string, error) {
 	owner, repo, err := findGitHubRepo(gopkg)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("find GitHub repo: %w", err)
 	}
 
 	rr, _, err := gitHub.Repositories.Get(context.TODO(), owner, repo)

--- a/search.go
+++ b/search.go
@@ -20,7 +20,7 @@ func getGolangBinaries() (map[string]string, error) {
 
 	resp, err := http.Get(golangBinariesURL)
 	if err != nil {
-		return nil, fmt.Errorf("getting %q: %v", golangBinariesURL, err)
+		return nil, fmt.Errorf("getting %q: %w", golangBinariesURL, err)
 	}
 	if got, want := resp.StatusCode, http.StatusOK; got != want {
 		return nil, fmt.Errorf("unexpected HTTP status code: got %d, want %d", got, want)
@@ -31,7 +31,7 @@ func getGolangBinaries() (map[string]string, error) {
 		Source         string `json:"source"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&pkgs); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("decode: %w", err)
 	}
 	for _, pkg := range pkgs {
 		if !strings.HasSuffix(pkg.Binary, "-dev") {

--- a/template.go
+++ b/template.go
@@ -16,46 +16,46 @@ func writeTemplates(dir, gopkg, debsrc, debLib, debProg, debversion string,
 ) error {
 
 	if err := os.Mkdir(filepath.Join(dir, "debian"), 0755); err != nil {
-		return err
+		return fmt.Errorf("mkdir debian/: %w", err)
 	}
 	if err := os.Mkdir(filepath.Join(dir, "debian", "source"), 0755); err != nil {
-		return err
+		return fmt.Errorf("mkdir debian/source/: %w", err)
 	}
 
 	if err := writeDebianChangelog(dir, debsrc, debversion); err != nil {
-		return err
+		return fmt.Errorf("write changelog: %w", err)
 	}
 	if err := writeDebianControl(dir, gopkg, debsrc, debLib, debProg, pkgType, dependencies); err != nil {
-		return err
+		return fmt.Errorf("write control: %w", err)
 	}
 	if err := writeDebianCopyright(dir, gopkg, u.vendorDirs, u.hasGodeps); err != nil {
-		return err
+		return fmt.Errorf("write copyright: %w", err)
 	}
 	if err := writeDebianRules(dir, pkgType); err != nil {
-		return err
+		return fmt.Errorf("write rules: %w", err)
 	}
 
 	var repack bool = len(u.vendorDirs) > 0 || u.hasGodeps
 	if err := writeDebianWatch(dir, gopkg, debsrc, u.hasRelease, repack); err != nil {
-		return err
+		return fmt.Errorf("write watch: %w", err)
 	}
 
 	if err := writeDebianSourceFormat(dir); err != nil {
-		return err
+		return fmt.Errorf("write source/format: %w", err)
 	}
 	if err := writeDebianPackageInstall(dir, debLib, debProg, pkgType); err != nil {
-		return err
+		return fmt.Errorf("write install: %w", err)
 	}
 	if err := writeDebianUpstreamMetadata(dir, gopkg); err != nil {
-		return err
+		return fmt.Errorf("write upstream metadata: %w", err)
 	}
 
 	if err := writeDebianGbpConf(dir, dep14, pristineTar); err != nil {
-		return err
+		return fmt.Errorf("write gbp conf: %w", err)
 	}
 
 	if err := writeDebianGitLabCI(dir); err != nil {
-		return err
+		return fmt.Errorf("write GitLab CI: %w", err)
 	}
 
 	return nil

--- a/version.go
+++ b/version.go
@@ -51,11 +51,11 @@ func pkgVersionFromGit(gitdir string, u *upstream, forcePrerelease bool) (string
 		cmd.Dir = gitdir
 		out, err := cmd.Output()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("git rev-list: %w", err)
 		}
 		commitsAhead, err = strconv.Atoi(strings.TrimSpace(string(out)))
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("parse commits ahead: %w", err)
 		}
 
 		if commitsAhead == 0 {
@@ -93,11 +93,11 @@ func pkgVersionFromGit(gitdir string, u *upstream, forcePrerelease bool) (string
 	cmd.Dir = gitdir
 	lastCommitUnixBytes, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("git log: %w", err)
 	}
 	lastCommitUnix, err := strconv.ParseInt(strings.TrimSpace(string(lastCommitUnixBytes)), 0, 64)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("parse last commit date: %w", err)
 	}
 
 	// This results in an output like "v4.10.2-232-g9f107c8"
@@ -112,7 +112,7 @@ func pkgVersionFromGit(gitdir string, u *upstream, forcePrerelease bool) (string
 		cmd.Stderr = os.Stderr
 		revparseBytes, err := cmd.Output()
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("git rev-parse: %w", err)
 		}
 		lastCommitHash = strings.TrimSpace(string(revparseBytes))
 		u.commitIsh = lastCommitHash


### PR DESCRIPTION
This will prevent situations when program terminates with bare error leaving the user without any clue of where the error was occurred.