### PR TITLE
CI was broken because of a missing directory

### DIFF
--- a/template.go
+++ b/template.go
@@ -427,6 +427,7 @@ test_the_archive:
     # Create an overlay to discard writes to /srv/gopath/src after the build:
     - "rm -rf /cache/overlay/{upper,work}"
     - "mkdir -p /cache/overlay/{upper,work}"
+    - "[[ -d /srv/gopath/src ]] || mkdir -p /srv/gopath/src"
     - "mount -t overlay overlay -o lowerdir=/srv/gopath/src,upperdir=/cache/overlay/upper,workdir=/cache/overlay/work /srv/gopath/src"
     - "export GOPATH=/srv/gopath"
     - "export GOCACHE=/cache/go"


### PR DESCRIPTION
See:
https://salsa.debian.org/go-team/packages/golang-github-pkg-diff/-/jobs/1430397
and
https://salsa.debian.org/go-team/packages/golang-github-pkg-diff/-/jobs/1432360

I am not sure if this should applies to everyone, and I have also opened a MR on salsa: https://salsa.debian.org/go-team/ci/-/merge_requests/3