### PR TITLE
Check for and move upstream debian dir if it exists

### DIFF
--- a/template.go
+++ b/template.go
@@ -16,7 +16,18 @@ func writeTemplates(dir, gopkg, debsrc, debLib, debProg, debversion string,
 ) error {
 
 	if err := os.Mkdir(filepath.Join(dir, "debian"), 0755); err != nil {
-		return err
+		// If upstream debian dir exists, try to move it aside, and then below.
+		if err := os.Rename(filepath.Join(dir, "debian"), filepath.Join(dir, "upstream_debian")); err != nil {
+			return err
+		} else {  // Second attempt to create template debian dir, after moving upstream dir aside.
+			if err := os.Mkdir(filepath.Join(dir, "debian"), 0755); err != nil {
+				return err
+			}
+			if err := os.Rename(filepath.Join(dir, "upstream_debian"), filepath.Join(dir, "debian/upstream_debian")); err != nil {
+				return err
+			}
+			log.Printf("WARNING: Upstream debian/ dir found, and relocated to debian/upstream_debian/\n")
+		}
 	}
 	if err := os.Mkdir(filepath.Join(dir, "debian", "source"), 0755); err != nil {
 		return err


### PR DESCRIPTION
Trying dh-make-golang on a git repo where upstream has a debian/ subdirectory errors with version 0.4.0.

This patch temporarily moves aside an existing debian/ directory, and then moves it into debian/upstream_debian .

Example of this error situation in v0.4.0:

$ dh-make-golang make -type="prog" github.com/la5nta/pat
...
2021/02/20 21:51:01 Could not create debian/ from templates: mkdir /tmp/x0/pat/debian: file exists