### PR TITLE
Add step (go.step.sm) to knownHosts

### DIFF
--- a/make.go
+++ b/make.go
@@ -554,6 +554,7 @@ func shortHostName(gopkg string, allowUnknownHoster bool) (host string, err erro
 		"git.sr.ht":         "sourcehut",
 		"github.com":        "github",
 		"gitlab.com":        "gitlab",
+		"go.step.sm":        "step",
 		"go.uber.org":       "uber",
 		"go4.org":           "go4",
 		"gocloud.dev":       "gocloud",


### PR DESCRIPTION
Adds `go.step.sm` using canonical identifier `step`