### PR TITLE
Add mongodb to known hosts

### DIFF
--- a/make.go
+++ b/make.go
@@ -578,6 +578,7 @@ func shortHostName(gopkg string, allowUnknownHoster bool) (host string, err erro
 		"github.com":           "github",
 		"gitlab.com":           "gitlab",
 		"go.cypherpunks.ru":    "cypherpunks",
+		"go.mongodb.org":       "mongodb",
 		"go.opentelemetry.io":  "opentelemetry",
 		"go.step.sm":           "step",
 		"go.uber.org":          "uber",


### PR DESCRIPTION
This is required by the go.mongodb.org/mongo-driver modules.