### PR TITLE
Reorder generated fields

### DIFF
--- a/template.go
+++ b/template.go
@@ -190,11 +190,11 @@ func writeDebianControl(dir, gopkg, debsrc, debLib, debProg string, pkgType pack
 	// Source package:
 
 	fmt.Fprintf(f, "Source: %s\n", debsrc)
+	fmt.Fprintf(f, "Section: golang\n")
+	fmt.Fprintf(f, "Priority: optional\n")
 	fmt.Fprintf(f, "Maintainer: Debian Go Packaging Team <team+pkg-go@tracker.debian.org>\n")
 	fprintfControlField(f, "Uploaders", []string{getDebianName() + " <" + getDebianEmail() + ">"})
-	fmt.Fprintf(f, "Section: golang\n")
-	fmt.Fprintf(f, "Testsuite: autopkgtest-pkg-go\n")
-	fmt.Fprintf(f, "Priority: optional\n")
+	fmt.Fprintf(f, "Rules-Requires-Root: no\n")
 
 	builddeps := append([]string{
 		"debhelper-compat (= 13)",
@@ -204,11 +204,11 @@ func writeDebianControl(dir, gopkg, debsrc, debLib, debProg string, pkgType pack
 	sort.Strings(builddeps)
 	fprintfControlField(f, "Build-Depends", builddeps)
 
+	fmt.Fprintf(f, "Testsuite: autopkgtest-pkg-go\n")
 	fmt.Fprintf(f, "Standards-Version: 4.6.0\n")
 	fmt.Fprintf(f, "Vcs-Browser: https://salsa.debian.org/go-team/packages/%s\n", debsrc)
 	fmt.Fprintf(f, "Vcs-Git: https://salsa.debian.org/go-team/packages/%s.git\n", debsrc)
 	fmt.Fprintf(f, "Homepage: %s\n", getHomepageForGopkg(gopkg))
-	fmt.Fprintf(f, "Rules-Requires-Root: no\n")
 	fmt.Fprintf(f, "XS-Go-Import-Path: %s\n", gopkg)
 
 	// Binary package(s):
@@ -259,9 +259,9 @@ func writeDebianCopyright(dir, gopkg string, vendorDirs []string, hasGodeps bool
 	}
 
 	fmt.Fprintf(f, "Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/\n")
+	fmt.Fprintf(f, "Source: %s\n", getHomepageForGopkg(gopkg))
 	fmt.Fprintf(f, "Upstream-Name: %s\n", filepath.Base(gopkg))
 	fmt.Fprintf(f, "Upstream-Contact: TODO\n")
-	fmt.Fprintf(f, "Source: %s\n", getHomepageForGopkg(gopkg))
 	if len(vendorDirs) > 0 || hasGodeps {
 		fmt.Fprintf(f, "Files-Excluded:\n")
 		for _, dir := range vendorDirs {


### PR DESCRIPTION
While stylistic, the rationale for these changes is as follows:

= debian/control

- Group Section and Priority together as these categorize the package, and place them after Source or Package fields, as this determines where in the archive these might end up.
- Place Maintainer/Uploader after these, as the responsible party for the package.
- Move Rules-Requires-Root before Build-Depends, as this determines how to drive the building process, and might impose additional dependencies, such as fakeroot or sudo.
- Move the Testsuite after the Build-Depends, as this is part of the runnable metadata.

= debian/copyright

- Move the Source field after Format, as both line up, refer to an URL, and it's the first reference to the upstream project.

These tend to be the changes I do on packages I've ITPed, as they jump on my face pretty quickly. :smile: 