### PR TITLE
Set a Section: TODO field for program packages

### DIFF
--- a/template.go
+++ b/template.go
@@ -173,6 +173,7 @@ func addLibraryPackage(f *os.File, gopkg, debLib string, dependencies []string) 
 func addProgramPackage(f *os.File, gopkg, debProg string) {
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "Package: %s\n", debProg)
+	fmt.Fprintf(f, "Section: TODO\n")
 	fmt.Fprintf(f, "Architecture: any\n")
 	deps := []string{"${misc:Depends}", "${shlibs:Depends}"}
 	fprintfControlField(f, "Depends", deps)


### PR DESCRIPTION
The golang section is for Go development packages, the fact that a program is written in Go is generally of no major relevance for the user, and instead a more suitable section relative to its actual functionality should be used, to help a proper categorization in the archive.