### PR TITLE
Update fields emitted

### DIFF
--- a/check_depends_test.go
+++ b/check_depends_test.go
@@ -24,7 +24,7 @@ Build-Depends:
  golang-github-jroimartin-gocui-dev,
  golang-github-mattn-go-sqlite3-dev,
  golang-github-mmcdole-gofeed-dev,
-Standards-Version: 4.5.1
+Standards-Version: 4.7.0
 Vcs-Browser: https://salsa.debian.org/go-team/packages/terminews
 Vcs-Git: https://salsa.debian.org/go-team/packages/terminews.git
 Homepage: https://github.com/antavelos/terminews

--- a/check_depends_test.go
+++ b/check_depends_test.go
@@ -36,8 +36,8 @@ Architecture: any
 Depends:
  ${misc:Depends},
  ${shlibs:Depends},
-Built-Using:
- ${misc:Built-Using},
+Static-Built-Using:
+ ${misc:Static-Built-Using},
 Description: read your RSS feeds from your terminal
  Terminews is a terminal based application (TUI)
  that allows you to manage RSS resources and display their news feeds.

--- a/template.go
+++ b/template.go
@@ -177,7 +177,7 @@ func addProgramPackage(f *os.File, gopkg, debProg string) {
 	fmt.Fprintf(f, "Architecture: any\n")
 	deps := []string{"${misc:Depends}", "${shlibs:Depends}"}
 	fprintfControlField(f, "Depends", deps)
-	fmt.Fprintf(f, "Built-Using: ${misc:Built-Using}\n")
+	fmt.Fprintf(f, "Static-Built-Using: ${misc:Static-Built-Using}\n")
 	addDescription(f, gopkg, "(program)")
 }
 

--- a/template.go
+++ b/template.go
@@ -206,7 +206,7 @@ func writeDebianControl(dir, gopkg, debsrc, debLib, debProg string, pkgType pack
 	fprintfControlField(f, "Build-Depends", builddeps)
 
 	fmt.Fprintf(f, "Testsuite: autopkgtest-pkg-go\n")
-	fmt.Fprintf(f, "Standards-Version: 4.6.2\n")
+	fmt.Fprintf(f, "Standards-Version: 4.7.0\n")
 	fmt.Fprintf(f, "Vcs-Browser: https://salsa.debian.org/go-team/packages/%s\n", debsrc)
 	fmt.Fprintf(f, "Vcs-Git: https://salsa.debian.org/go-team/packages/%s.git\n", debsrc)
 	fmt.Fprintf(f, "Homepage: %s\n", getHomepageForGopkg(gopkg))


### PR DESCRIPTION
This series updates the `Standards-Version` field version, and switches from the `Built-Using` to the `Static-Built-Using` field, following the migration done in the `dh-golang` package.