### PR TITLE
Use DEP-14 branch names `debian/latest` and `upstream/latest`

### DIFF
--- a/make.go
+++ b/make.go
@@ -417,6 +417,14 @@ func runGitCommandIn(dir string, arg ...string) error {
 
 func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, dep14 bool, pristineTar bool) (string, error) {
+
+	// debianBranch is passed in function call, but upstream import branch needs
+	// also to be defined
+	upstreamImportBranch := "upstream"
+	if dep14 {
+		upstreamImportBranch = "upstream/latest"
+	}
+
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get cwd: %w", err)
@@ -471,7 +479,8 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 
 	// Preconfigure branches
 
-	branches := []string{debianBranch, "upstream/latest"}
+	branches := []string{debianBranch, upstreamImportBranch}
+
 	if pristineTar {
 		branches = append(branches, "pristine-tar")
 	}
@@ -485,13 +494,8 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 	}
 
 	if includeUpstreamHistory {
-		u.remote, err = shortHostName(gopkg, allowUnknownHoster)
-		if err != nil {
-			return dir, fmt.Errorf("unable to fetch upstream history: %q", err)
-		}
-		if u.remote == "debian" {
-			u.remote = "salsa"
-		}
+		// Always call the upstream git remote 'upstreamvcs' just like git-buildpackage does
+		u.remote = "upstreamvcs"
 		log.Printf("Adding remote %q with URL %q\n", u.remote, u.rr.Repo)
 		if err := runGitCommandIn(dir, "remote", "add", u.remote, u.rr.Repo); err != nil {
 			return dir, fmt.Errorf("git remote add %s %s: %w", u.remote, u.rr.Repo, err)
@@ -503,10 +507,13 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 	}
 
 	// Import upstream orig tarball
+	// (and release git tag if includeUpstreamHistory)
 
-	arg := []string{"import-orig", "--no-interactive", "--debian-branch=" + debianBranch}
-	if dep14 {
-		arg = append(arg, "--upstream-branch=upstream/latest")
+	arg := []string{
+		"import-orig",
+		"--no-interactive",
+		"--debian-branch=" + debianBranch,
+		"--upstream-branch=" + upstreamImportBranch,
 	}
 	if pristineTar {
 		arg = append(arg, "--pristine-tar")

--- a/make.go
+++ b/make.go
@@ -416,7 +416,8 @@ func runGitCommandIn(dir string, arg ...string) error {
 }
 
 func createGitRepository(debsrc, gopkg, orig string, u *upstream,
-	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, dep14 bool, pristineTar bool) (string, error) {
+	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string,
+	dep14 bool, pristineTar bool) (string, error) {
 
 	// debianBranch is passed in function call, but upstream import branch needs
 	// also to be defined

--- a/make.go
+++ b/make.go
@@ -416,7 +416,7 @@ func runGitCommandIn(dir string, arg ...string) error {
 }
 
 func createGitRepository(debsrc, gopkg, orig string, u *upstream,
-	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, pristineTar bool) (string, error) {
+	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, dep14 bool, pristineTar bool) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get cwd: %w", err)
@@ -471,7 +471,7 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 
 	// Preconfigure branches
 
-	branches := []string{debianBranch, "upstream"}
+	branches := []string{debianBranch, "upstream/latest"}
 	if pristineTar {
 		branches = append(branches, "pristine-tar")
 	}
@@ -505,6 +505,9 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 	// Import upstream orig tarball
 
 	arg := []string{"import-orig", "--no-interactive", "--debian-branch=" + debianBranch}
+	if dep14 {
+		arg = append(arg, "--upstream-branch=upstream/latest")
+	}
 	if pristineTar {
 		arg = append(arg, "--pristine-tar")
 	}
@@ -786,7 +789,7 @@ func execMake(args []string, usage func()) {
 	fs.BoolVar(&dep14,
 		"dep14",
 		true,
-		"Follow DEP-14 branch naming and use debian/sid (instead of master)\n"+
+		"Follow DEP-14 branch naming and use debian/latest (instead of master)\n"+
 			"as the default debian-branch.")
 
 	var pristineTar bool
@@ -896,7 +899,7 @@ func execMake(args []string, usage func()) {
 	// Set the debian branch.
 	debBranch := "master"
 	if dep14 {
-		debBranch = "debian/sid"
+		debBranch = "debian/latest"
 	}
 
 	switch strings.TrimSpace(wrapAndSort) {
@@ -987,7 +990,7 @@ func execMake(args []string, usage func()) {
 
 	debversion := u.version + "-1"
 
-	dir, err := createGitRepository(debsrc, gopkg, orig, u, includeUpstreamHistory, allowUnknownHoster, debBranch, pristineTar)
+	dir, err := createGitRepository(debsrc, gopkg, orig, u, includeUpstreamHistory, allowUnknownHoster, debBranch, dep14, pristineTar)
 	if err != nil {
 		log.Fatalf("Could not create git repository: %v\n", err)
 	}

--- a/make.go
+++ b/make.go
@@ -435,17 +435,8 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 		return "", fmt.Errorf("mkdir: %w", err)
 	}
 
-	// "git init -b" is the one-liner we need here, however it was added in Git 2.28.
-	// For now we prefer to keep compatibility with older Git, so we do it in two
-	// rounds, "git init" then "git checkout".
-	//if err := runGitCommandIn(dir, "init", "-b", debianBranch); err != nil {
-	//	return dir, err
-	//}
-	if err := runGitCommandIn(dir, "init"); err != nil {
+	if err := runGitCommandIn(dir, "init", "-b", debianBranch); err != nil {
 		return dir, fmt.Errorf("git init: %w", err)
-	}
-	if err := runGitCommandIn(dir, "checkout", "-q", "-b", debianBranch); err != nil {
-		return dir, fmt.Errorf("git checkout: %w", err)
 	}
 
 	// Set repository options

--- a/template.go
+++ b/template.go
@@ -337,7 +337,8 @@ func writeDebianGbpConf(dir string, dep14, pristineTar bool) error {
 
 	fmt.Fprintf(f, "[DEFAULT]\n")
 	if dep14 {
-		fmt.Fprintf(f, "debian-branch = debian/sid\n")
+		fmt.Fprintf(f, "debian-branch = debian/latest\n")
+		fmt.Fprintf(f, "upstream-branch = upstream/latest\n")
 		fmt.Fprintf(f, "dist = DEP14\n")
 	}
 	if pristineTar {

--- a/template.go
+++ b/template.go
@@ -342,8 +342,40 @@ func writeDebianGbpConf(dir string, dep14, pristineTar bool) error {
 		fmt.Fprintf(f, "dist = DEP14\n")
 	}
 	if pristineTar {
-		fmt.Fprintf(f, "pristine-tar = True\n")
+		fmt.Fprintf(f, `
+# Always use pristine tar to improve supply chain security and auditability
+pristine-tar = True
+
+`)
 	}
+
+	// Additional text to the template which is useful for 99% of the go packages
+	fmt.Fprint(f, `
+# Lax requirement to use branch name 'debian/latest' so that git-buildpackage
+# will always build using the currently checked out branch as the Debian branch.
+# This makes it easier for contributors to work with feature and bugfix
+# branches.
+ignore-branch = True
+
+# Configure the upstream tag format below, so that 'gbp import-orig' will run
+# correctly, and link tarball import branch ('upstream/latest') with the
+# equivalent upstream release tag, showing a complete audit trail of what
+# upstream released and what was imported into Debian.
+#
+# Most Go packages have tags of form 'v1.0.0'
+upstream-vcs-tag = v%(version%~%-)s
+
+# If upstream publishes tarball signatures, git-buildpackage will by default
+# import and use the them. Change this to 'on' to make 'gbp import-orig' abort
+# if the signature is not found or is not valid.
+#
+# Most Go packages don't publish signatures for the tarball releases, so this is
+# not enabled by default.
+#upstream-signatures = on
+
+# Ensure the Debian maintainer signs git tags automatically
+sign-tags = True
+`)
 	return nil
 }
 


### PR DESCRIPTION
In DEP-14, the preferred branch name for the Debian packaging target branch is `debian/latest` and the preferred name for the upstream import target branch is `upstream/latest`. Note that the upstream development branch name can be whatever and should stay as it is upstream, typically `main` or `master`. The branch `upstream/latest` should not point to the latest upstream development commit, but to the latest commit that was used as the upstream release that the Debian revision was derived from.