### PR TITLE
dh-make-golang make: directly use the user preferred tag specified in "-git_revision" option

### DIFF
--- a/make.go
+++ b/make.go
@@ -386,7 +386,7 @@ func makeUpstreamSourceTarball(repo, revision string, forcePrerelease bool) (*up
 
 	log.Printf("Determining upstream version number\n")
 
-	u.version, err = pkgVersionFromGit(repoDir, &u, forcePrerelease)
+	u.version, err = pkgVersionFromGit(repoDir, &u, revision, forcePrerelease)
 	if err != nil {
 		return nil, fmt.Errorf("get package version from Git: %w", err)
 	}

--- a/version_test.go
+++ b/version_test.go
@@ -45,7 +45,7 @@ func TestSnapshotVersion(t *testing.T) {
 	}
 
 	var u upstream
-	got, err := pkgVersionFromGit(tempdir, &u, false)
+	got, err := pkgVersionFromGit(tempdir, &u, "", false)
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestSnapshotVersion(t *testing.T) {
 
 	gitCmdOrFatal(t, tempdir, "tag", "-a", "v1", "-m", "release v1")
 
-	got, err = pkgVersionFromGit(tempdir, &u, false)
+	got, err = pkgVersionFromGit(tempdir, &u, "", false)
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}
@@ -75,7 +75,7 @@ func TestSnapshotVersion(t *testing.T) {
 		t.Fatalf("Could not run %v: %v", cmd.Args, err)
 	}
 
-	got, err = pkgVersionFromGit(tempdir, &u, false)
+	got, err = pkgVersionFromGit(tempdir, &u, "", false)
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}
@@ -95,7 +95,7 @@ func TestSnapshotVersion(t *testing.T) {
 		t.Fatalf("Could not run %v: %v", cmd.Args, err)
 	}
 
-	got, err = pkgVersionFromGit(tempdir, &u, false)
+	got, err = pkgVersionFromGit(tempdir, &u, "", false)
 	if err != nil {
 		t.Fatalf("Determining package version from git failed: %v", err)
 	}


### PR DESCRIPTION
When a user specifies a valid tag when using

    dh-make-golang make -git_revision {some valid tag}

if there is another tag pointing to the same commit as the specified tag, then dh-make-golang might use the other tag to determine the package version.

This patch modifies the behavior of "dh-make-golang make" such that, if the user specifies a valid tag in "-git_revision" option, "dh-make-golang make" will always use the specified tag to determine the upstream package version.

This patch also trivially changes the tests written in version_test.go so that the tests adjusts to the new function signature of version.go:pkgVersionFromGit().