### PR TITLE
fix release tags not recognized when not on a branch

### DIFF
--- a/make.go
+++ b/make.go
@@ -493,8 +493,8 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 		if err := runGitCommandIn(dir, "remote", "add", u.remote, u.rr.Repo); err != nil {
 			return dir, fmt.Errorf("git remote add %s %s: %w", u.remote, u.rr.Repo, err)
 		}
-		log.Printf("Running \"git fetch %s\"\n", u.remote)
-		if err := runGitCommandIn(dir, "fetch", u.remote); err != nil {
+		log.Printf("Running \"git fetch --tags %s\"\n", u.remote)
+		if err := runGitCommandIn(dir, "fetch", "--tags", u.remote); err != nil {
 			return dir, fmt.Errorf("git fetch %s: %w", u.remote, err)
 		}
 	}


### PR DESCRIPTION
"dh-make-golang" creates the "debianized" source repo from scratch. It creates an empty git repo, adds the upstream as a remote, and fetches the tags. However, before this patch, it is using "git fetch" with no additional flags or options. This results in upstream tags not on any branches not being picked up. This patch adds "--tags" flag to "git fetch" so that it can fetch all upstream tags.