### PR TITLE
Include cross-links in man pages

### DIFF
--- a/dh-make-golang.md
+++ b/dh-make-golang.md
@@ -40,6 +40,10 @@ command is executed. To learn more about a command, run
 
 Run **dh-make-golang** -help for more details.
 
+# SEE ALSO
+
+**dh**(1), **dh_golang**(1), **Debian::Debhelper::Buildsystem::golang**(3pm)
+
 # AUTHOR
 
 This manual page was written by Michael Stapelberg <stapelberg@debian.org>


### PR DESCRIPTION
Make dh_golang and dh-make-golang easier to discover by people eading man pages about Go packaging in Debian.

Current versions for reference:
- https://manpages.debian.org/unstable/dh-golang/Debian::Debhelper::Buildsystem::golang.3pm.en.html
- https://manpages.debian.org/unstable/dh-golang/dh_golang.1p.en.html
- https://manpages.debian.org/unstable/dh-make-golang/dh-make-golang.1.en.html


Related: https://salsa.debian.org/go-team/packages/dh-golang/-/merge_requests/24
