### PR TITLE
ci-test: Fix syntax/formatting check so it actually emits an exit code

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -23,7 +23,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
           check-latest: true
 
-      - run: diff -u <(echo -n) <(gofmt -d -s .)
+      - run: gofmt -w -s . && git diff --exit-code --color
 
       - run: go install -v ./...
 


### PR DESCRIPTION
I noticed this bug while working on #225 and I saw this:

https://github.com/Debian/dh-make-golang/actions/runs/12617186618/job/35159206853

![image](https://github.com/user-attachments/assets/97c2e52d-66c8-4c29-ad50-fc12df84b90a)


The old format didn't emit any exit codes and thus did not cause CI to fail:

    $ diff -u <(echo -n) <(gofmt -d -s .)
    make.go:513:46: missing ',' before newline in composite literal
    $ echo $?
    0

The smallest possible fix to this is to ensure gofmt output actually goes to stdout as the original test expected:

    $ diff -u <(echo -n) <(gofmt -d -s . 2>&1)
    --- /dev/fd/63	2025-01-05 07:46:28.550632333 +0000
    +++ /dev/fd/62	2025-01-05 07:46:28.550632333 +0000
    @@ -0,0 +1 @@
    +make.go:513:46: missing ',' before newline in composite literal
    $ echo $?
    1
