### PR TITLE
Apply wrap-and-sort -at by default

### DIFF
--- a/make.go
+++ b/make.go
@@ -827,7 +827,7 @@ func execMake(args []string, usage func()) {
 
 	fs.StringVar(&wrapAndSort,
 		"wrap-and-sort",
-		"a",
+		"at",
 		"Set how the various multi-line fields in debian/control are formatted.\n"+
 			"Valid values are \"a\", \"at\" and \"ast\", see wrap-and-sort(1) man page\n"+
 			"for more information.")


### PR DESCRIPTION
The Go team currently recommends the flags --wrap-always --trailing-comma [1] which translates to -at, so dh-make-golang should use this flag combination by default.

[1] https://go-team.pages.debian.net/workflow-changes.html#wf-2017-11-debian-control