### PR TITLE
Fix dh-make-golang estimate

### DIFF
--- a/estimate.go
+++ b/estimate.go
@@ -68,20 +68,17 @@ func removeVendor(gopath string) (found bool, _ error) {
 	return found, err
 }
 
-func isFile(path string) bool {
-	if info, err := os.Stat(path); err == nil {
-		return !info.IsDir()
-	}
-	return false
-}
-
 func estimate(importpath string) error {
 	// construct a separate GOPATH in a temporary directory
 	gopath, err := os.MkdirTemp("", "dh-make-golang")
 	if err != nil {
 		return fmt.Errorf("create temp dir: %w", err)
 	}
-	defer os.RemoveAll(gopath)
+	defer func() {
+		if err := forceRemoveAll(gopath); err != nil {
+			log.Printf("could not remove all %s: %v", gopath, err)
+		}
+	}()
 
 	// clone the repo inside the src directory of the GOPATH
 	// and init a Go module if it is not yet one.

--- a/estimate.go
+++ b/estimate.go
@@ -230,7 +230,7 @@ func estimate(importpath string) error {
 		log.Printf("%s is already fully packaged in Debian", importpath)
 		return nil
 	}
-	log.Printf("Bringing %s to Debian requires packaging the following Go packages:", importpath)
+	log.Printf("Bringing %s to Debian requires packaging the following Go modules:", importpath)
 	for _, line := range lines {
 		fmt.Println(line)
 	}
@@ -242,8 +242,8 @@ func execEstimate(args []string) {
 	fs := flag.NewFlagSet("estimate", flag.ExitOnError)
 
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s estimate <go-package-importpath>\n", os.Args[0])
-		fmt.Fprintf(os.Stderr, "Estimates the work necessary to bring <go-package-importpath> into Debian\n"+
+		fmt.Fprintf(os.Stderr, "Usage: %s estimate <go-module-importpath>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Estimates the work necessary to bring <go-module-importpath> into Debian\n"+
 			"by printing all currently unpacked repositories.\n")
 		fmt.Fprintf(os.Stderr, "Example: %s estimate github.com/Debian/dh-make-golang\n", os.Args[0])
 	}

--- a/fs_utils.go
+++ b/fs_utils.go
@@ -6,14 +6,6 @@ import (
 	"path/filepath"
 )
 
-// isFile checks if a path exists and is a file (not a directory).
-func isFile(path string) bool {
-	if info, err := os.Stat(path); err == nil {
-		return !info.IsDir()
-	}
-	return false
-}
-
 // forceRemoveAll is a more robust alternative to [os.RemoveAll] that tries
 // harder to remove all the files and directories.
 func forceRemoveAll(path string) error {

--- a/fs_utils.go
+++ b/fs_utils.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// isFile checks if a path exists and is a file (not a directory).
+func isFile(path string) bool {
+	if info, err := os.Stat(path); err == nil {
+		return !info.IsDir()
+	}
+	return false
+}
+
+// forceRemoveAll is a more robust alternative to [os.RemoveAll] that tries
+// harder to remove all the files and directories.
+func forceRemoveAll(path string) error {
+	// first pass to make sure all the directories are writable
+	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if info.IsDir() {
+			return os.Chmod(path, 0777)
+		} else {
+			// remove files by the way
+			return os.Remove(path)
+		}
+	})
+	if err != nil {
+		return err
+	}
+	// remove the remaining directories
+	return os.RemoveAll(path)
+}


### PR DESCRIPTION
As support for the [gopath mode of "go get" has been removed in Go 1.22](https://tip.golang.org/doc/go1.22#go-command), we cannot use the GO111MODULE=off trick any more:

> `go get` is no longer supported outside of a module in the legacy `GOPATH` mode (that is, with `GO111MODULE=off`).

To fix the estimate command, we now download the sources of the repo manually then run "go get" in the repo dir to make use of the information contained in the go.mod file and download the dependencies.

For go packages that are not modules yet, we init ourselves a go module using "go mod init".

Closes: #159
Closes: #231
Closes: #89
Supersedes: #137

-----

The third commit introduces a new method for retrieving the dependencies based on [`go mod graph`](https://go.dev/ref/mod#go-mod-graph). From my (limited) testing this is faster and more robust, but it is still a little bit imprecise. See the [commit message](https://github.com/Debian/dh-make-golang/pull/240/commits/7bc360945766ad51e1c4fb4d9cf61ae345b8a82c) for more information.

------

The fourth commit adds checks for other major versions already packaged in Debian. It is a bit imprecise because the `XS-Go-Import-Path:` metadata in `debian/control` is often outdated and does not reflect the current import path. But IMO it is better to show it than to hide it, as upgrading a package to a new major version is not always easy/possible.

For example with the same example as in the previous commit, we get this kind of output:

```
2025/01/06 16:22:07 github.com/charmbracelet/x/conpty is packaged as github.com/charmbracelet/x in Debian
2025/01/06 16:22:07 github.com/charmbracelet/x/termios is packaged as github.com/charmbracelet/x in Debian
2025/01/06 16:22:07 github.com/charmbracelet/x/errors is packaged as github.com/charmbracelet/x in Debian
2025/01/06 16:22:07 github.com/charmbracelet/x/ansi is packaged as github.com/charmbracelet/x in Debian
2025/01/06 16:22:07 github.com/charmbracelet/x/exp/golden is packaged as github.com/charmbracelet/x in Debian
2025/01/06 16:22:07 github.com/charmbracelet/x/term is packaged as github.com/charmbracelet/x in Debian
2025/01/06 16:22:07 Bringing github.com/charmbracelet/vhs to Debian requires packaging the following Go packages:
github.com/charmbracelet/vhs
  github.com/caarlos0/env/v11	(github.com/caarlos0/env in Debian)
  github.com/charmbracelet/ssh
  github.com/erikgeiser/coninput
  github.com/go-rod/rod
    github.com/ysmood/fetchup
      github.com/ysmood/got
      github.com/ysmood/gop
    github.com/ysmood/goob
      github.com/ysmood/gotrace
    github.com/ysmood/gson
    github.com/ysmood/leakless
  github.com/mattn/go-localereader
```

------

~There are still some issues with repos that contain multiple modules (go workspaces) and repos that do not have their go module at the root. But this can be enhanced later (or maybe in this PR if I have the time).~
Just did it in the fifth commit.

------

As a last proposition, but this is more a matter of taste, I pushed in a separate branch the commit https://github.com/n-peugnet/dh-make-golang/commit/d156df1644458c7aefa905a477c279c7e6258a4c (best viewed which whitespaces disabled). It shows duplicated dependencies but dimmed, the commit message explains why. Here is a before and after this commit:

![2025-01-06-232316_497x197_scrot](https://github.com/user-attachments/assets/d33665a1-52f4-4317-be6c-f1d2769ed658)

After https://github.com/n-peugnet/dh-make-golang/commit/d156df1644458c7aefa905a477c279c7e6258a4c:

![2025-01-06-231804_497x392_scrot](https://github.com/user-attachments/assets/c0d678d7-d750-426e-b212-e3fe2d556fb6)
