### PR TITLE
estimate: show duplicated modules import path and repository path, but dimmed

### DIFF
--- a/estimate.go
+++ b/estimate.go
@@ -174,50 +174,58 @@ func estimate(importpath string) error {
 	// Analyse the dependency graph
 	var lines []string
 	seen := make(map[string]bool)
+	needed := make(map[string]int)
 	var visit func(n *Node, indent int)
 	visit = func(n *Node, indent int) {
 		// Get the module name without its version, as go mod graph
 		// can return multiple times the same module with different
 		// versions.
 		mod, _, _ := strings.Cut(n.name, "@")
-		if seen[mod] {
+		count, isNeeded := needed[mod]
+		if isNeeded {
+			count++
+			needed[mod] = count
+			lines = append(lines, fmt.Sprintf("%s\033[90m%s (%d)\033[0m", strings.Repeat("  ", indent), mod, count))
+		} else if seen[mod] {
 			return
-		}
-		seen[mod] = true
-		// Go version dependency is indicated as a dependency to "go" and
-		// "toolchain", we do not use this information for now.
-		if mod == "go" || mod == "toolchain" {
-			return
-		}
-		if _, ok := golangBinaries[mod]; ok {
-			return // already packaged in Debian
-		}
-		var debianVersion string
-		// Check for potential other major versions already in Debian.
-		for _, otherVersion := range otherVersions(mod) {
-			if _, ok := golangBinaries[otherVersion]; ok {
-				debianVersion = otherVersion
-				break
-			}
-		}
-		if debianVersion == "" {
-			// When multiple modules are developped in the same repo,
-			// the repo root is often used as the import path metadata
-			// in Debian, so we do a last try with that.
-			rr, err := vcs.RepoRootForImportPath(mod, false)
-			if err != nil {
-				log.Printf("Could not determine repo path for import path %q: %v\n", mod, err)
-			} else if _, ok := golangBinaries[rr.Root]; ok {
-				// Log info to indicate that it is an approximate match
-				// but consider that it is packaged and skip the children.
-				log.Printf("%s is packaged as %s in Debian", mod, rr.Root)
+		} else {
+			seen[mod] = true
+			// Go version dependency is indicated as a dependency to "go" and
+			// "toolchain", we do not use this information for now.
+			if mod == "go" || mod == "toolchain" {
 				return
 			}
-		}
-		if debianVersion != "" {
-			lines = append(lines, fmt.Sprintf("%s%s\t(%s in Debian)", strings.Repeat("  ", indent), mod, debianVersion))
-		} else {
-			lines = append(lines, fmt.Sprintf("%s%s", strings.Repeat("  ", indent), mod))
+			if _, ok := golangBinaries[mod]; ok {
+				return // already packaged in Debian
+			}
+			var debianVersion string
+			// Check for potential other major versions already in Debian.
+			for _, otherVersion := range otherVersions(mod) {
+				if _, ok := golangBinaries[otherVersion]; ok {
+					debianVersion = otherVersion
+					break
+				}
+			}
+			if debianVersion == "" {
+				// When multiple modules are developped in the same repo,
+				// the repo root is often used as the import path metadata
+				// in Debian, so we do a last try with that.
+				rr, err := vcs.RepoRootForImportPath(mod, false)
+				if err != nil {
+					log.Printf("Could not determine repo path for import path %q: %v\n", mod, err)
+				} else if _, ok := golangBinaries[rr.Root]; ok {
+					// Log info to indicate that it is an approximate match
+					// but consider that it is packaged and skip the children.
+					log.Printf("%s is packaged as %s in Debian", mod, rr.Root)
+					return
+				}
+			}
+			if debianVersion != "" {
+				lines = append(lines, fmt.Sprintf("%s%s\t(%s in Debian)", strings.Repeat("  ", indent), mod, debianVersion))
+			} else {
+				lines = append(lines, fmt.Sprintf("%s%s", strings.Repeat("  ", indent), mod))
+			}
+			needed[mod] = 1
 		}
 		for _, n := range n.children {
 			visit(n, indent+1)


### PR DESCRIPTION
### Description

As a follow-up of #240 I am proposing this change, that allows to see how often a module is required in the dependency graph.

- **Show and indicate duplicate dependencies**

  Previously, when a dependency was seen multiple times, it was deduplicated. This helped seeing the exact number of modules that needed to be packaged, but it didn't help seeing the most used modules to package in priority.
  
  Now, we show duplicate packages but in a dimmed color and with a count of occurences in parenthesis at the end. The colors allows to still quickly evaluate the effort by focusing the eyes on the deduplicated list, while the count helps detecting the most used module.

- **Only highlight unique repositories in estimate**

  Keep printing all needed modules recursively, but instead of only dimming the duplicated modules, we also dim the rest of the import path after the repo root, and modules whose repo root has already been printed. This allows to only highlight the repository names (the actual thing that we package in Debian) and only once, so it give a better appreciation of the work packaging work required.

### Example

Here is an example, showing the result of `dh-make-golang estimate github.com/charmbracelet/vhs`, but hacked a little to make as if `github.com/charmbracelet/x` is not yet packaged in Debian.

**Before**:
![2025-01-14-132038_485x287_scrot](https://github.com/user-attachments/assets/506f9303-ddc3-464f-9a41-32ca4b689ed8)

**After**:
![2025-01-14-132301_485x557_scrot](https://github.com/user-attachments/assets/1d07486e-d6a0-4a3e-9ac3-8692ae2f7040)


We can see that:

1. Duplicate modules are shown but dimmed and with a counter next to them
1. `/v11` is dimmed, as the repository root is in fact `github.com/caarlos0/env` (maybe it would be better not to dim it, I'm not sure).
2. `/conpty` is dimmed as well, as the module is in a subfolder of the `github.com/charmbracelet/x` repository
3. All modules of `github.com/charmbracelet/x` afterwards are completely dimmed, as they are part of an already printed repository.

This allows to easily find the corresponding repositories (by copying only the highlighted parts) and to better estimate the packaging work needed.

In fact, If I'm not mistaken, the highlighted part of this picture is the exact output of the estimate command before #240, when it was still working.

I was thinking of adding an additionnal textual indication for packages with duplicated repository path, to be able to have this information even when only the test is copy-pasted. For example, an asterisk at the end, but I am not sure yet.