### PR TITLE
Use current URL for CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![CI Test](https://github.com/anthonyfok/dh-make-golang/actions/workflows/ci-test.yml/badge.svg)
+![CI Test](https://github.com/Debian/dh-make-golang/actions/workflows/ci-test.yml/badge.svg)
 
 dh-make-golang is a tool to automatically create Debian packaging for Go
 packages. Its goal is to automate away as much of the work as possible when


### PR DESCRIPTION
Just noticed this small discrepancy.