### PR TITLE
Revert workflow changes that got rushed and merged with no Go team agreement nor consensus

### DIFF
--- a/make.go
+++ b/make.go
@@ -416,8 +416,7 @@ func runGitCommandIn(dir string, arg ...string) error {
 }
 
 func createGitRepository(debsrc, gopkg, orig string, u *upstream,
-	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string,
-	dep14 bool, pristineTar bool) (string, error) {
+	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, dep14 bool, pristineTar bool) (string, error) {
 
 	// debianBranch is passed in function call, but upstream import branch needs
 	// also to be defined

--- a/make.go
+++ b/make.go
@@ -416,7 +416,7 @@ func runGitCommandIn(dir string, arg ...string) error {
 }
 
 func createGitRepository(debsrc, gopkg, orig string, u *upstream,
-	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, dep14 bool, pristineTar bool) (string, error) {
+	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, pristineTar bool) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get cwd: %w", err)
@@ -462,7 +462,7 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 
 	// Preconfigure branches
 
-	branches := []string{debianBranch, "upstream/latest"}
+	branches := []string{debianBranch, "upstream"}
 	if pristineTar {
 		branches = append(branches, "pristine-tar")
 	}
@@ -496,9 +496,6 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 	// Import upstream orig tarball
 
 	arg := []string{"import-orig", "--no-interactive", "--debian-branch=" + debianBranch}
-	if dep14 {
-		arg = append(arg, "--upstream-branch=upstream/latest")
-	}
 	if pristineTar {
 		arg = append(arg, "--pristine-tar")
 	}
@@ -780,7 +777,7 @@ func execMake(args []string, usage func()) {
 	fs.BoolVar(&dep14,
 		"dep14",
 		true,
-		"Follow DEP-14 branch naming and use debian/latest (instead of master)\n"+
+		"Follow DEP-14 branch naming and use debian/sid (instead of master)\n"+
 			"as the default debian-branch.")
 
 	var pristineTar bool
@@ -890,7 +887,7 @@ func execMake(args []string, usage func()) {
 	// Set the debian branch.
 	debBranch := "master"
 	if dep14 {
-		debBranch = "debian/latest"
+		debBranch = "debian/sid"
 	}
 
 	switch strings.TrimSpace(wrapAndSort) {
@@ -981,7 +978,7 @@ func execMake(args []string, usage func()) {
 
 	debversion := u.version + "-1"
 
-	dir, err := createGitRepository(debsrc, gopkg, orig, u, includeUpstreamHistory, allowUnknownHoster, debBranch, dep14, pristineTar)
+	dir, err := createGitRepository(debsrc, gopkg, orig, u, includeUpstreamHistory, allowUnknownHoster, debBranch, pristineTar)
 	if err != nil {
 		log.Fatalf("Could not create git repository: %v\n", err)
 	}

--- a/make.go
+++ b/make.go
@@ -521,6 +521,29 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 		return dir, fmt.Errorf("import-orig: %w", err)
 	}
 
+	{
+		f, err := os.OpenFile(filepath.Join(dir, ".gitignore"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return dir, fmt.Errorf("open .gitignore: %w", err)
+		}
+		// Beginning newline in case the file already exists and lacks a newline
+		// (not all editors enforce a newline at the end of the file):
+		if _, err := f.Write([]byte("\n/.pc/\n/_build/\n")); err != nil {
+			return dir, fmt.Errorf("write to .gitignore: %w", err)
+		}
+		if err := f.Close(); err != nil {
+			return dir, fmt.Errorf("close .gitignore: %w", err)
+		}
+	}
+
+	if err := runGitCommandIn(dir, "add", ".gitignore"); err != nil {
+		return dir, fmt.Errorf("git add .gitignore: %w", err)
+	}
+
+	if err := runGitCommandIn(dir, "commit", "-m", "Ignore _build and quilt .pc dirs via .gitignore"); err != nil {
+		return dir, fmt.Errorf("git commit (.gitignore): %w", err)
+	}
+
 	return dir, nil
 }
 

--- a/template.go
+++ b/template.go
@@ -342,40 +342,8 @@ func writeDebianGbpConf(dir string, dep14, pristineTar bool) error {
 		fmt.Fprintf(f, "dist = DEP14\n")
 	}
 	if pristineTar {
-		fmt.Fprintf(f, `
-# Always use pristine tar to improve supply chain security and auditability
-pristine-tar = True
-
-`)
+		fmt.Fprintf(f, "pristine-tar = True\n")
 	}
-
-	// Additional text to the template which is useful for 99% of the go packages
-	fmt.Fprint(f, `
-# Lax requirement to use branch name 'debian/latest' so that git-buildpackage
-# will always build using the currently checked out branch as the Debian branch.
-# This makes it easier for contributors to work with feature and bugfix
-# branches.
-ignore-branch = True
-
-# Configure the upstream tag format below, so that 'gbp import-orig' will run
-# correctly, and link tarball import branch ('upstream/latest') with the
-# equivalent upstream release tag, showing a complete audit trail of what
-# upstream released and what was imported into Debian.
-#
-# Most Go packages have tags of form 'v1.0.0'
-upstream-vcs-tag = v%(version%~%-)s
-
-# If upstream publishes tarball signatures, git-buildpackage will by default
-# import and use the them. Change this to 'on' to make 'gbp import-orig' abort
-# if the signature is not found or is not valid.
-#
-# Most Go packages don't publish signatures for the tarball releases, so this is
-# not enabled by default.
-#upstream-signatures = on
-
-# Ensure the Debian maintainer signs git tags automatically
-sign-tags = True
-`)
 	return nil
 }
 

--- a/template.go
+++ b/template.go
@@ -86,7 +86,6 @@ func writeDebianGitIgnore(dir, debLib, debProg string, pkgType packageType) erro
 	fmt.Fprintf(f, "*.log\n")
 	fmt.Fprintf(f, "*.substvars\n")
 	fmt.Fprintf(f, "/.debhelper/\n")
-	fmt.Fprintf(f, "/build/\n")
 	fmt.Fprintf(f, "/debhelper-build-stamp\n")
 	fmt.Fprintf(f, "/files\n")
 
@@ -300,12 +299,7 @@ func writeDebianRules(dir string, pkgType packageType) error {
 	fmt.Fprintf(f, "#!/usr/bin/make -f\n")
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "%%:\n")
-	fmt.Fprintf(f, "\tdh $@ --builddirectory=debian/build --buildsystem=golang\n")
-	// Note: The above `--builddirectory=debian/build` will eventually be obsolete
-	// in 2028+ then the dh-golang version 1.63+ that has
-	// https://salsa.debian.org/go-team/packages/dh-golang/-/commit/bc16dff5381b668a71fa99c381baba202c34c789
-	// is in use everywhere
-
+	fmt.Fprintf(f, "\tdh $@ --builddirectory=_build --buildsystem=golang\n")
 	if pkgType == typeProgram {
 		fmt.Fprintf(f, "\n")
 		fmt.Fprintf(f, "override_dh_auto_install:\n")

--- a/template.go
+++ b/template.go
@@ -337,8 +337,7 @@ func writeDebianGbpConf(dir string, dep14, pristineTar bool) error {
 
 	fmt.Fprintf(f, "[DEFAULT]\n")
 	if dep14 {
-		fmt.Fprintf(f, "debian-branch = debian/latest\n")
-		fmt.Fprintf(f, "upstream-branch = upstream/latest\n")
+		fmt.Fprintf(f, "debian-branch = debian/sid\n")
 		fmt.Fprintf(f, "dist = DEP14\n")
 	}
 	if pristineTar {


### PR DESCRIPTION
This reverts several controversial changes.

This was pushed and merged in a rush without Go team agreement or consensus, based on false premises where even the DEP it is based on does not have any mention of there being defaults preferences for these changes, where there's been recorded objections in general in the Debian project at large in the past, and where even existing practice (as analyzed by the same author) does not support these defaults being the majority in use.

This should also unblock a pending upload to fix release critical bugs in the package in Debian.

Ref: https://lists.debian.org/debian-devel/2024/08/msg00299.html