### PR TITLE
Extend default debian/gbp.conf with extra security config tips

### DIFF
--- a/template.go
+++ b/template.go
@@ -341,8 +341,40 @@ func writeDebianGbpConf(dir string, dep14, pristineTar bool) error {
 		fmt.Fprintf(f, "dist = DEP14\n")
 	}
 	if pristineTar {
-		fmt.Fprintf(f, "pristine-tar = True\n")
+		fmt.Fprintf(f, `
+# Always use pristine tar to improve supply chain security and auditability
+pristine-tar = True
+
+`)
 	}
+
+	// Additional text to the template which is useful for 99% of the go packages
+	fmt.Fprint(f, `
+# Lax requirement to use branch name 'debian/latest' so that git-buildpackage
+# will always build using the currently checked out branch as the Debian branch.
+# This makes it easier for contributors to work with feature and bugfix
+# branches.
+ignore-branch = True
+
+# Configure the upstream tag format below, so that 'gbp import-orig' will run
+# correctly, and link tarball import branch ('upstream/latest') with the
+# equivalent upstream release tag, showing a complete audit trail of what
+# upstream released and what was imported into Debian.
+#
+# Most Go packages have tags of form 'v1.0.0'
+upstream-vcs-tag = v%(version%~%-)s
+
+# If upstream publishes tarball signatures, git-buildpackage will by default
+# import and use the them. Change this to 'on' to make 'gbp import-orig' abort
+# if the signature is not found or is not valid.
+#
+# Most Go packages don't publish signatures for the tarball releases, so this is
+# not enabled by default.
+#upstream-signatures = on
+
+# Ensure the Debian maintainer signs git tags automatically
+sign-tags = True
+`)
 	return nil
 }
 


### PR DESCRIPTION
When creating a new package, populate the git-buildpackage with additional configs and in-line comments on why and how to use them. This will make go packaging easier, more consistent and more secure as the best practices flow to all packages via good defaults.

Also add comment to explain why pristine-tar is beneficial.