### PR TITLE
Use DEP-14 branch names debian/latest and upstream/latest, and upstream vcs remote name 'upstreamvcs'

### DIFF
--- a/make.go
+++ b/make.go
@@ -417,7 +417,8 @@ func runGitCommandIn(dir string, arg ...string) error {
 }
 
 func createGitRepository(debsrc, gopkg, orig string, u *upstream,
-	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, pristineTar bool) (string, error) {
+	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string,
+	dep14 bool, pristineTar bool) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get cwd: %w", err)
@@ -463,7 +464,7 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 
 	// Preconfigure branches
 
-	branches := []string{debianBranch, "upstream"}
+	branches := []string{debianBranch, "upstream/latest"}
 	if pristineTar {
 		branches = append(branches, "pristine-tar")
 	}
@@ -497,6 +498,9 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 	// Import upstream orig tarball
 
 	arg := []string{"import-orig", "--no-interactive", "--debian-branch=" + debianBranch}
+	if dep14 {
+		arg = append(arg, "--upstream-branch=upstream/latest")
+	}
 	if pristineTar {
 		arg = append(arg, "--pristine-tar")
 	}
@@ -759,7 +763,7 @@ func execMake(args []string, usage func()) {
 	fs.BoolVar(&dep14,
 		"dep14",
 		true,
-		"Follow DEP-14 branch naming and use debian/sid (instead of master)\n"+
+		"Follow DEP-14 branch naming and use debian/latest (instead of master)\n"+
 			"as the default debian-branch.")
 
 	var pristineTar bool
@@ -869,7 +873,7 @@ func execMake(args []string, usage func()) {
 	// Set the debian branch.
 	debBranch := "master"
 	if dep14 {
-		debBranch = "debian/sid"
+		debBranch = "debian/latest"
 	}
 
 	switch strings.TrimSpace(wrapAndSort) {
@@ -960,7 +964,7 @@ func execMake(args []string, usage func()) {
 
 	debversion := u.version + "-1"
 
-	dir, err := createGitRepository(debsrc, gopkg, orig, u, includeUpstreamHistory, allowUnknownHoster, debBranch, pristineTar)
+	dir, err := createGitRepository(debsrc, gopkg, orig, u, includeUpstreamHistory, allowUnknownHoster, debBranch, dep14, pristineTar)
 	if err != nil {
 		log.Fatalf("Could not create git repository: %v\n", err)
 	}

--- a/template.go
+++ b/template.go
@@ -352,7 +352,8 @@ func writeDebianGbpConf(dir string, dep14, pristineTar bool) error {
 
 	fmt.Fprintf(f, "[DEFAULT]\n")
 	if dep14 {
-		fmt.Fprintf(f, "debian-branch = debian/sid\n")
+		fmt.Fprintf(f, "debian-branch = debian/latest\n")
+		fmt.Fprintf(f, "upstream-branch = upstream/latest\n")
 		fmt.Fprintf(f, "dist = DEP14\n")
 	}
 	if pristineTar {


### PR DESCRIPTION
See commits for details. This is a re-submission of #225, pending to be merged potentially in the summer of 2025.