### PR TITLE
Stop modifying upstream .gitignore file and put build artifacts in debian/build/

### DIFF
--- a/make.go
+++ b/make.go
@@ -510,29 +510,6 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 		return dir, fmt.Errorf("import-orig: %w", err)
 	}
 
-	{
-		f, err := os.OpenFile(filepath.Join(dir, ".gitignore"), os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			return dir, fmt.Errorf("open .gitignore: %w", err)
-		}
-		// Beginning newline in case the file already exists and lacks a newline
-		// (not all editors enforce a newline at the end of the file):
-		if _, err := f.Write([]byte("\n/.pc/\n/_build/\n")); err != nil {
-			return dir, fmt.Errorf("write to .gitignore: %w", err)
-		}
-		if err := f.Close(); err != nil {
-			return dir, fmt.Errorf("close .gitignore: %w", err)
-		}
-	}
-
-	if err := runGitCommandIn(dir, "add", ".gitignore"); err != nil {
-		return dir, fmt.Errorf("git add .gitignore: %w", err)
-	}
-
-	if err := runGitCommandIn(dir, "commit", "-m", "Ignore _build and quilt .pc dirs via .gitignore"); err != nil {
-		return dir, fmt.Errorf("git commit (.gitignore): %w", err)
-	}
-
 	return dir, nil
 }
 

--- a/template.go
+++ b/template.go
@@ -86,6 +86,7 @@ func writeDebianGitIgnore(dir, debLib, debProg string, pkgType packageType) erro
 	fmt.Fprintf(f, "*.log\n")
 	fmt.Fprintf(f, "*.substvars\n")
 	fmt.Fprintf(f, "/.debhelper/\n")
+	fmt.Fprintf(f, "/build/\n")
 	fmt.Fprintf(f, "/debhelper-build-stamp\n")
 	fmt.Fprintf(f, "/files\n")
 
@@ -299,7 +300,12 @@ func writeDebianRules(dir string, pkgType packageType) error {
 	fmt.Fprintf(f, "#!/usr/bin/make -f\n")
 	fmt.Fprintf(f, "\n")
 	fmt.Fprintf(f, "%%:\n")
-	fmt.Fprintf(f, "\tdh $@ --builddirectory=_build --buildsystem=golang\n")
+	fmt.Fprintf(f, "\tdh $@ --builddirectory=debian/build --buildsystem=golang\n")
+	// Note: The above `--builddirectory=debian/build` will eventually be obsolete
+	// in 2028+ then the dh-golang version 1.63+ that has
+	// https://salsa.debian.org/go-team/packages/dh-golang/-/commit/bc16dff5381b668a71fa99c381baba202c34c789
+	// is in use everywhere
+
 	if pkgType == typeProgram {
 		fmt.Fprintf(f, "\n")
 		fmt.Fprintf(f, "override_dh_auto_install:\n")


### PR DESCRIPTION
See commits for details. This is a re-submission of #230, pending to be merged potentially in the summer of 2025.