### PR TITLE
make: MIME-encode sender name when necessary

### DIFF
--- a/make.go
+++ b/make.go
@@ -690,9 +690,11 @@ func writeITP(gopkg, debsrc, debversion string) (string, error) {
 		description = "TODO"
 	}
 
+	subject := mime.QEncoding.Encode("utf-8", fmt.Sprintf("ITP: %s -- %s", debsrc, description))
+
 	fmt.Fprintf(f, "From: %q <%s>\n", mime.QEncoding.Encode("utf-8", getDebianName()), getDebianEmail())
 	fmt.Fprintf(f, "To: submit@bugs.debian.org\n")
-	fmt.Fprintf(f, "Subject: ITP: %s -- %s\n", debsrc, description)
+	fmt.Fprintf(f, "Subject: %s\n", subject)
 	fmt.Fprintf(f, "Content-Type: text/plain; charset=utf-8\n")
 	fmt.Fprintf(f, "Content-Transfer-Encoding: 8bit\n")
 	fmt.Fprintf(f, "X-Debbugs-CC: debian-devel@lists.debian.org, debian-go@lists.debian.org\n")

--- a/make.go
+++ b/make.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net/http"
 	"net/url"
 	"os"
@@ -689,7 +690,7 @@ func writeITP(gopkg, debsrc, debversion string) (string, error) {
 		description = "TODO"
 	}
 
-	fmt.Fprintf(f, "From: %q <%s>\n", getDebianName(), getDebianEmail())
+	fmt.Fprintf(f, "From: %q <%s>\n", mime.QEncoding.Encode("utf-8", getDebianName()), getDebianEmail())
 	fmt.Fprintf(f, "To: submit@bugs.debian.org\n")
 	fmt.Fprintf(f, "Subject: ITP: %s -- %s\n", debsrc, description)
 	fmt.Fprintf(f, "Content-Type: text/plain; charset=utf-8\n")


### PR DESCRIPTION
Otherwise sending the generated ITP files as is will fail for people
(like me) who have non-ASCII characters in their names.
