### PR TITLE
Stop using `Rules-Requires-Root: no`, which is the default in Trixie

### DIFF
--- a/check_depends_test.go
+++ b/check_depends_test.go
@@ -28,7 +28,6 @@ Standards-Version: 4.7.0
 Vcs-Browser: https://salsa.debian.org/go-team/packages/terminews
 Vcs-Git: https://salsa.debian.org/go-team/packages/terminews.git
 Homepage: https://github.com/antavelos/terminews
-Rules-Requires-Root: no
 XS-Go-Import-Path: github.com/antavelos/terminews
 
 Package: terminews

--- a/template.go
+++ b/template.go
@@ -195,7 +195,6 @@ func writeDebianControl(dir, gopkg, debsrc, debLib, debProg string, pkgType pack
 	fmt.Fprintf(f, "Priority: optional\n")
 	fmt.Fprintf(f, "Maintainer: Debian Go Packaging Team <team+pkg-go@tracker.debian.org>\n")
 	fprintfControlField(f, "Uploaders", []string{getDebianName() + " <" + getDebianEmail() + ">"})
-	fmt.Fprintf(f, "Rules-Requires-Root: no\n")
 
 	builddeps := append([]string{
 		"debhelper-compat (= 13)",


### PR DESCRIPTION
Starting from Trixie, this d/control file stanza is unnecessary and e.g. lintian-brush automatically removes it. Stop propagating it in new Go packages now.

For details see
https://lists.debian.org/debian-devel/2024/12/msg00637.html