### PR TITLE
estimate: show packages in NEW, but with a light blue color

### DIFF
--- a/check_depends.go
+++ b/check_depends.go
@@ -91,7 +91,7 @@ func execCheckDepends(args []string) {
 // parseGoModDependencies parse ALL dependencies listed in go.mod
 // i.e. it returns the one defined in go.mod as well as the transitively ones
 // TODO: this may not be the best way of doing thing since it requires the package to be converted to go module
-func parseGoModDependencies(directory string, goBinaries map[string]string) ([]dependency, error) {
+func parseGoModDependencies(directory string, goBinaries map[string]debianPackage) ([]dependency, error) {
 	b, err := os.ReadFile(filepath.Join(directory, "go.mod"))
 	if err != nil {
 		return nil, err
@@ -115,7 +115,7 @@ func parseGoModDependencies(directory string, goBinaries map[string]string) ([]d
 			}
 
 			if val, exists := goBinaries[rr.Root]; exists {
-				packageName = val
+				packageName = val.binary
 			}
 
 			dependencies = append(dependencies, dependency{

--- a/check_depends_test.go
+++ b/check_depends_test.go
@@ -111,10 +111,10 @@ require (
 		t.Fatalf("Could not create dummy Debian package: %v", err)
 	}
 
-	deps, err := parseGoModDependencies(filepath.Join(tmpDir, "dummy-package"), map[string]string{
-		"github.com/charmbracelet/glamour": "golang-github-charmbracelet-glamour-dev",
-		"github.com/google/go-github":      "golang-github-google-go-github-dev",
-		"github.com/gregjones/httpcache":   "golang-github-gregjones-httpcache-dev",
+	deps, err := parseGoModDependencies(filepath.Join(tmpDir, "dummy-package"), map[string]debianPackage{
+		"github.com/charmbracelet/glamour": {binary: "golang-github-charmbracelet-glamour-dev", source: "golang-github-charmbracelet-glamour"},
+		"github.com/google/go-github":      {binary: "golang-github-google-go-github-dev", source: "golang-github-google-go-github"},
+		"github.com/gregjones/httpcache":   {binary: "golang-github-gregjones-httpcache-dev", source: "golang-github-gregjones-httpcache"},
 	})
 	if err != nil {
 		t.Fatalf("Could not parse go.mod dependencies: %v", err)

--- a/estimate.go
+++ b/estimate.go
@@ -142,6 +142,13 @@ func trackerLink(pkg string) string {
 	return fmt.Sprintf("\033]8;;https://tracker.debian.org/pkg/%[1]s\033\\%[1]s\033]8;;\033\\", pkg)
 }
 
+// newPackageLine generates a line for packages in NEW, including an OSC 8
+// hyperlink to the FTP masters website for the given Debian package.
+func newPackageLine(indent int, mod, debpkg, version string) string {
+	const format = "%s\033[36m%s (\033]8;;https://ftp-master.debian.org/new/%s_%s.html\033\\in NEW\033]8;;\033\\)\033[0m"
+	return fmt.Sprintf(format, strings.Repeat("  ", indent), mod, debpkg, version)
+}
+
 func estimate(importpath, revision string) error {
 	removeTemp := func(path string) {
 		if err := forceRemoveAll(path); err != nil {
@@ -267,8 +274,8 @@ func estimate(importpath, revision string) error {
 				return
 			}
 			if pkg, ok := golangBinaries[mod]; ok {
-				if _, ok := sourcesInNew[pkg.source]; ok {
-					line := fmt.Sprintf("%s\033[36m%s (in NEW)\033[0m", strings.Repeat("  ", indent), mod)
+				if version, ok := sourcesInNew[pkg.source]; ok {
+					line := newPackageLine(indent, mod, pkg.source, version)
 					lines = append(lines, line)
 				}
 				return // already packaged in Debian
@@ -291,8 +298,8 @@ func estimate(importpath, revision string) error {
 				} else {
 					log.Printf("%s is v%d in Debian (%s)", mod, v, trackerLink(pkg.source))
 				}
-				if _, ok := sourcesInNew[pkg.source]; ok {
-					line := fmt.Sprintf("%s\033[36m%s (in NEW)\033[0m", strings.Repeat("  ", indent), mod)
+				if version, ok := sourcesInNew[pkg.source]; ok {
+					line := newPackageLine(indent, mod, pkg.source, version)
 					lines = append(lines, line)
 				}
 				return
@@ -304,8 +311,8 @@ func estimate(importpath, revision string) error {
 				// Log info to indicate that it is an approximate match
 				// but consider that it is packaged and skip the children.
 				log.Printf("%s is packaged as %s in Debian (%s)", mod, repoRoot, trackerLink(pkg.source))
-				if _, ok := sourcesInNew[pkg.source]; ok {
-					line := fmt.Sprintf("%s\033[36m%s (in NEW)\033[0m", strings.Repeat("  ", indent), mod)
+				if version, ok := sourcesInNew[pkg.source]; ok {
+					line := newPackageLine(indent, mod, pkg.source, version)
 					lines = append(lines, line)
 				}
 				return

--- a/make.go
+++ b/make.go
@@ -930,7 +930,7 @@ func execMake(args []string, usage func()) {
 
 	var (
 		eg             errgroup.Group
-		golangBinaries map[string]string // map[goImportPath]debianBinaryPackage
+		golangBinaries map[string]debianPackage // map[goImportPath]debianPackage
 	)
 
 	// TODO: also check whether there already is a git repository on salsa.
@@ -963,9 +963,9 @@ func execMake(args []string, usage func()) {
 		log.Printf("Could not check for existing Go packages in Debian: %v", err)
 	}
 
-	if debbin, ok := golangBinaries[gopkg]; ok {
+	if debpkg, ok := golangBinaries[gopkg]; ok {
 		log.Printf("WARNING: A package called %q is already in Debian! See https://tracker.debian.org/pkg/%s\n",
-			debbin, debbin)
+			debpkg.binary, debpkg.source)
 	}
 
 	orig := fmt.Sprintf("%s_%s.orig.tar.%s", debsrc, u.version, u.compression)
@@ -993,12 +993,12 @@ func execMake(args []string, usage func()) {
 			debdependencies = append(debdependencies, debianNameFromGopkg(dep, typeLibrary, "", allowUnknownHoster)+"-dev")
 			continue
 		}
-		bin, ok := golangBinaries[dep]
+		pkg, ok := golangBinaries[dep]
 		if !ok {
 			log.Printf("Build-Dependency %q is not yet available in Debian, or has not yet been converted to use XS-Go-Import-Path in debian/control", dep)
 			continue
 		}
-		debdependencies = append(debdependencies, bin)
+		debdependencies = append(debdependencies, pkg.binary)
 	}
 
 	if err := writeTemplates(dir, gopkg, debsrc, debLib, debProg, debversion,

--- a/search.go
+++ b/search.go
@@ -15,8 +15,13 @@ const (
 	golangBinariesURL = "https://api.ftp-master.debian.org/binary/by_metadata/Go-Import-Path"
 )
 
-func getGolangBinaries() (map[string]string, error) {
-	golangBinaries := make(map[string]string)
+type debianPackage struct {
+	binary string
+	source string
+}
+
+func getGolangBinaries() (map[string]debianPackage, error) {
+	golangBinaries := make(map[string]debianPackage)
 
 	resp, err := http.Get(golangBinariesURL)
 	if err != nil {
@@ -39,7 +44,10 @@ func getGolangBinaries() (map[string]string, error) {
 		}
 		for _, importPath := range strings.Split(pkg.XSGoImportPath, ",") {
 			// XS-Go-Import-Path can be comma-separated and contain spaces.
-			golangBinaries[strings.TrimSpace(importPath)] = pkg.Binary
+			golangBinaries[strings.TrimSpace(importPath)] = debianPackage{
+				binary: pkg.Binary,
+				source: pkg.Source,
+			}
 		}
 	}
 	return golangBinaries, nil
@@ -74,9 +82,9 @@ func execSearch(args []string) {
 		log.Fatal(err)
 	}
 
-	for importPath, binary := range golangBinaries {
+	for importPath, pkg := range golangBinaries {
 		if pattern.MatchString(importPath) {
-			fmt.Printf("%s: %s\n", binary, importPath)
+			fmt.Printf("%s: %s\n", pkg.binary, importPath)
 		}
 	}
 }


### PR DESCRIPTION
It uses an additional query from the DAK Web API to get the packages currently in NEW, but this one returns only source packages, so we have to keep into memory the name of the source packages when we get the list of all golang packages.

Maybe the name `getGolangBinaries` is a bit misleading now.

Closes: #283 

Here is an example output:
![2025-06-27-182444_427x257_scrot](https://github.com/user-attachments/assets/a480159a-c031-4a8d-b5fe-0ec68e473647)

