### PR TITLE
metadata: trim .git suffix when searching github URL for gopkg

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -112,7 +112,7 @@ func findGitHubOwnerRepo(gopkg string) (string, error) {
 					return ""
 				}
 				if repoMatch := githubRegexp.FindStringSubmatch(f[2]); repoMatch != nil {
-					return repoMatch[1]
+					return strings.TrimSuffix(repoMatch[1], ".git")
 				}
 			}
 			return ""


### PR DESCRIPTION
Some go hosts have this suffix in their go-import metadata which broke fetching the repo metadat from GitHub's API, e.g. go.bug.st:

    Could not determine description for "go.bug.st/cleanup": GET https://api.github.com/repos/bugst/go-cleanup.git: 404 Not Found []
    Could not determine long description for "go.bug.st/cleanup": get readme: GET https://api.github.com/repos/bugst/go-cleanup.git/readme: 404 Not Found []
    Could not determine license for "go.bug.st/cleanup": get license for Go package: GET https://api.github.com/repos/bugst/go-cleanup.git/license: 404 Not Found []
    Could not determine copyright for "go.bug.st/cleanup": get repo: GET https://api.github.com/repos/bugst/go-cleanup.git: 404 Not Found []
