### PR TITLE
Add go.bug.st to known hosts

### DIFF
--- a/make.go
+++ b/make.go
@@ -580,6 +580,7 @@ func shortHostName(gopkg string, allowUnknownHoster bool) (host string, err erro
 		"git.sr.ht":            "sourcehut",
 		"github.com":           "github",
 		"gitlab.com":           "gitlab",
+		"go.bug.st":            "bugst",
 		"go.cypherpunks.ru":    "cypherpunks",
 		"go.mongodb.org":       "mongodb",
 		"go.opentelemetry.io":  "opentelemetry",


### PR DESCRIPTION
A few dependencies of arduino-cli use this domain for their import path.

I chose bugst as the short name as it is the one used for the github org where this domain is currently redirected: https://github.com/bugst
