### PR TITLE
Add fortio.org to known hosts

### DIFF
--- a/make.go
+++ b/make.go
@@ -576,6 +576,7 @@ func shortHostName(gopkg string, allowUnknownHoster bool) (host string, err erro
 		"code.google.com":      "googlecode",
 		"codeberg.org":         "codeberg",
 		"filippo.io":           "filippo",
+		"fortio.org":           "fortio",
 		"fyne.io":              "fyne",
 		"git.sr.ht":            "sourcehut",
 		"github.com":           "github",


### PR DESCRIPTION
They maintain a few dependencies under their own domain, one of them is used by arduino-cli which I am currently working on packaging.
