### PR TITLE
Add dpkg-build-api (= 1) to the default build-deps

### DIFF
--- a/check_depends_test.go
+++ b/check_depends_test.go
@@ -18,6 +18,7 @@ Priority: optional
 Build-Depends:
  debhelper-compat (= 13),
  dh-sequence-golang,
+ dpkg-build-api (= 1),
  golang-any,
  golang-github-advancedlogic-goose-dev,
  golang-github-fatih-color-dev,

--- a/template.go
+++ b/template.go
@@ -199,6 +199,7 @@ func writeDebianControl(dir, gopkg, debsrc, debLib, debProg string, pkgType pack
 	builddeps := append([]string{
 		"debhelper-compat (= 13)",
 		"dh-sequence-golang",
+		"dpkg-build-api (= 1)",
 		"golang-any"},
 		dependencies...)
 	sort.Strings(builddeps)


### PR DESCRIPTION
Closes: https://github.com/Debian/dh-make-golang/issues/289