### PR TITLE
Drop Priority: optional, which is the default in Trixie

### DIFF
--- a/check_depends_test.go
+++ b/check_depends_test.go
@@ -14,7 +14,6 @@ Uploaders:
  Aloïs Micard <alois@micard.lu>,
 Section: news
 Testsuite: autopkgtest-pkg-go
-Priority: optional
 Build-Depends:
  debhelper-compat (= 13),
  dh-sequence-golang,

--- a/template.go
+++ b/template.go
@@ -193,7 +193,6 @@ func writeDebianControl(dir, gopkg, debsrc, debLib, debProg string, pkgType pack
 
 	fmt.Fprintf(f, "Source: %s\n", debsrc)
 	fmt.Fprintf(f, "Section: golang\n")
-	fmt.Fprintf(f, "Priority: optional\n")
 	fmt.Fprintf(f, "Maintainer: Debian Go Packaging Team <team+pkg-go@tracker.debian.org>\n")
 	fprintfControlField(f, "Uploaders", []string{getDebianName() + " <" + getDebianEmail() + ">"})
 


### PR DESCRIPTION
When omitted, the priority defaults to optional (since dpkg 1.22.13).

Cf. `man deb-src-control`.