### PR TITLE
estimate: fix for modules that don't have a root package

### DIFF
--- a/estimate.go
+++ b/estimate.go
@@ -110,6 +110,12 @@ func getDirectDependencies(gopath, repodir, module string) (map[string]bool, err
 	if err != nil {
 		return nil, fmt.Errorf("get module dir: %w", err)
 	}
+	// We cannot use "go list -m ..." if there is no go.mod file, but
+	// such packages are usually quite old and have few dependencies,
+	// so we return a nil map without error.
+	if _, err := os.Stat(filepath.Join(dir, "go.mod")); err != nil {
+		return nil, nil
+	}
 	cmd := exec.Command("go", "list", "-m", "-f", "{{if not .Indirect}}{{.Path}}{{end}}", "all")
 	cmd.Dir = dir
 	cmd.Stderr = os.Stderr

--- a/estimate.go
+++ b/estimate.go
@@ -88,7 +88,7 @@ func get(gopath, repodir, repo, rev string) error {
 // getModuleDir returns the path of the directory containing a module for the
 // given GOPATH and repository dir values.
 func getModuleDir(gopath, repodir, module string) (string, error) {
-	cmd := exec.Command("go", "list", "-f", "{{.Dir}}", module)
+	cmd := exec.Command("go", "list", "-m", "-f", "{{.Dir}}", module)
 	cmd.Dir = repodir
 	cmd.Stderr = os.Stderr
 	cmd.Env = append([]string{


### PR DESCRIPTION
Some modules don't have any .go files in their root directory (e.g. github.com/autobrr/qui), which means they have no root package. This led to the error "no required module provides package foo" when trying to list the direct dependencies of the estimated module.

To fix this, we now make sure to use "go list" in module mode using the "-m" option when looking for the module directory in the GOPATH.

EDIT: to make it clear, here is the error fixed by this change:

```console
$ dh-make-golang estimate github.com/autobrr/qui
no required module provides package github.com/autobrr/qui; to add it:
	go get github.com/autobrr/qui
2025/09/23 13:44:54 estimate: get direct dependencies: get module dir: go list: args: [go list -f {{.Dir}} github.com/autobrr/qui]; error: exit status 1
```
