### PR TITLE
Relax acceptable `XS-Go-Import-Path` syntax

### DIFF
--- a/search.go
+++ b/search.go
@@ -32,7 +32,7 @@ type getGolangBinariesConfig struct {
 
 type getGolangBinariesOption func(cfg *getGolangBinariesConfig)
 
-func getGolangBinariesUrl(url string) getGolangBinariesOption {
+func withGolangBinariesUrl(url string) getGolangBinariesOption {
 	return func(cfg *getGolangBinariesConfig) {
 		cfg.url = url
 	}

--- a/search.go
+++ b/search.go
@@ -63,7 +63,15 @@ func getGolangBinaries(opts ...getGolangBinariesOption) (map[string]debianPackag
 		}
 		for importPath := range strings.SplitSeq(pkg.MetadataValue, ",") {
 			// XS-Go-Import-Path can be comma-separated and contain spaces.
-			golangBinaries[strings.TrimSpace(importPath)] = debianPackage{
+			importPath := strings.TrimSpace(importPath)
+			// importPath might be the empty string if XS-Go-Import-Path has a leading comma, trailing
+			// comma, or extraneous internal comma.  It might also be empty if api.ftp-master.d.o returns
+			// packages where XS-Go-Import-Path is explicitly set to the empty string or to a
+			// whitespace-only string.
+			if importPath == "" {
+				continue
+			}
+			golangBinaries[importPath] = debianPackage{
 				binary: pkg.Binary,
 				source: pkg.Source,
 			}

--- a/search.go
+++ b/search.go
@@ -26,6 +26,9 @@ type ftpMasterApiResult struct {
 	Source        string `json:"source"`
 }
 
+// Entries in XS-Go-Import-Path are separated by commas and/or spaces.
+var listSep = regexp.MustCompile(`[,\s]+`)
+
 type getGolangBinariesConfig struct {
 	url string
 }
@@ -61,13 +64,9 @@ func getGolangBinaries(opts ...getGolangBinariesOption) (map[string]debianPackag
 		if !strings.HasSuffix(pkg.Binary, "-dev") {
 			continue // skip -dbgsym packages etc.
 		}
-		for importPath := range strings.SplitSeq(pkg.MetadataValue, ",") {
-			// XS-Go-Import-Path can be comma-separated and contain spaces.
-			importPath := strings.TrimSpace(importPath)
-			// importPath might be the empty string if XS-Go-Import-Path has a leading comma, trailing
-			// comma, or extraneous internal comma.  It might also be empty if api.ftp-master.d.o returns
-			// packages where XS-Go-Import-Path is explicitly set to the empty string or to a
-			// whitespace-only string.
+		for _, importPath := range listSep.Split(pkg.MetadataValue, -1) {
+			// importPath might be the empty string if XS-Go-Import-Path has a leading or trailing
+			// listSep, or the entire string matches listSep*.
 			if importPath == "" {
 				continue
 			}

--- a/search_test.go
+++ b/search_test.go
@@ -22,6 +22,30 @@ func TestGetGolangBinaries(t *testing.T) {
 			results: nil,
 			want:    map[string]debianPackage{},
 		},
+		// It is unclear whether api.ftp-master.d.o would even return a result for a package whose
+		// metadata field is set to the empty string (as of 2026-02-26 there are no such results), but
+		// test the handling just in case.
+		{
+			desc: "empty",
+			results: []ftpMasterApiResult{{
+				Binary:        "golang-example-foo-dev",
+				MetadataValue: "",
+				Source:        "golang-example-foo",
+			}},
+			want: map[string]debianPackage{},
+		},
+		// It is unclear whether api.ftp-master.d.o would even return a result for a package whose
+		// metadata field is set to a whitespace-only string (as of 2026-02-26 there are no such
+		// results), but test the handling just in case.
+		{
+			desc: "whitespace-only",
+			results: []ftpMasterApiResult{{
+				Binary:        "golang-example-foo-dev",
+				MetadataValue: " \t\n\r",
+				Source:        "golang-example-foo",
+			}},
+			want: map[string]debianPackage{},
+		},
 		{
 			desc: "leading whitespace",
 			results: []ftpMasterApiResult{{
@@ -69,10 +93,65 @@ func TestGetGolangBinaries(t *testing.T) {
 			},
 		},
 		{
+			desc: "only commas",
+			results: []ftpMasterApiResult{{
+				Binary:        "golang-example-foo-dev",
+				MetadataValue: " ,\t,\n",
+				Source:        "golang-example-foo",
+			}},
+			want: map[string]debianPackage{},
+		},
+		{
 			desc: "space around comma",
 			results: []ftpMasterApiResult{{
 				Binary:        "golang-example-foo-dev",
 				MetadataValue: "example.com/foo ,\n\texample.com/bar",
+				Source:        "golang-example-foo",
+			}},
+			want: map[string]debianPackage{
+				"example.com/foo": {
+					binary: "golang-example-foo-dev",
+					source: "golang-example-foo",
+				},
+				"example.com/bar": {
+					binary: "golang-example-foo-dev",
+					source: "golang-example-foo",
+				},
+			},
+		},
+		{
+			desc: "leading comma",
+			results: []ftpMasterApiResult{{
+				Binary:        "golang-example-foo-dev",
+				MetadataValue: ",example.com/foo",
+				Source:        "golang-example-foo",
+			}},
+			want: map[string]debianPackage{
+				"example.com/foo": {
+					binary: "golang-example-foo-dev",
+					source: "golang-example-foo",
+				},
+			},
+		},
+		{
+			desc: "trailing comma",
+			results: []ftpMasterApiResult{{
+				Binary:        "golang-example-foo-dev",
+				MetadataValue: "example.com/foo,",
+				Source:        "golang-example-foo",
+			}},
+			want: map[string]debianPackage{
+				"example.com/foo": {
+					binary: "golang-example-foo-dev",
+					source: "golang-example-foo",
+				},
+			},
+		},
+		{
+			desc: "internal extra comma",
+			results: []ftpMasterApiResult{{
+				Binary:        "golang-example-foo-dev",
+				MetadataValue: "example.com/foo,,example.com/bar",
 				Source:        "golang-example-foo",
 			}},
 			want: map[string]debianPackage{

--- a/search_test.go
+++ b/search_test.go
@@ -165,6 +165,24 @@ func TestGetGolangBinaries(t *testing.T) {
 				},
 			},
 		},
+		{
+			desc: "whitespace separated",
+			results: []ftpMasterApiResult{{
+				Binary:        "golang-example-foo-dev",
+				MetadataValue: "example.com/foo \n\texample.com/bar",
+				Source:        "golang-example-foo",
+			}},
+			want: map[string]debianPackage{
+				"example.com/foo": {
+					binary: "golang-example-foo-dev",
+					source: "golang-example-foo",
+				},
+				"example.com/bar": {
+					binary: "golang-example-foo-dev",
+					source: "golang-example-foo",
+				},
+			},
+		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()

--- a/search_test.go
+++ b/search_test.go
@@ -95,7 +95,7 @@ func TestGetGolangBinaries(t *testing.T) {
 				}
 			}))
 			defer ts.Close()
-			got, err := getGolangBinaries(getGolangBinariesUrl(ts.URL))
+			got, err := getGolangBinaries(withGolangBinariesUrl(ts.URL))
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This PR relaxes how `XS-Go-Import-Path` values are parsed to improve maintainer friendliness:

  * Filter out empty string values in `XS-Go-Import-Path` (in particular, ignore a trailing comma).
  * Allow values to be separated by spaces and/or commas.