### PR TITLE
ci-test: Bump Go versions to 1.24 and 1.26

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -11,7 +11,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        go-version: ['1.21', '1.22']
+        go-version: ['1.22', '1.24', '1.26']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Following example 989837ab but match the Go versions in Debian unstable currently in 2026.