### PR TITLE
Fix invalid syntax in gitlab-ci.yml (regression from af68dbf7)

### DIFF
--- a/template.go
+++ b/template.go
@@ -542,7 +542,7 @@ include:
 	const compatContent = `# This file exists only for backwards compatibility and can be removed once all
 # documentation and tools have migrated to use the new file name 'salsa-ci.yml'
 include:
-	- local: '/debian/salsa-ci.yml'
+  - local: '/debian/salsa-ci.yml'
 `
 	fmt.Fprint(fCompat, compatContent)
 

--- a/template.go
+++ b/template.go
@@ -357,7 +357,6 @@ func writeDebianGbpConf(dir string, dep14, pristineTar bool) error {
 	}
 	if pristineTar {
 		fmt.Fprintf(f, `
-
 # Enable pristine-tar for git-buildpackage to exactly reproduce orig tarballs
 pristine-tar = True
 `)
@@ -365,7 +364,6 @@ pristine-tar = True
 
 	// Additional text to the template which is useful for most Go packages
 	fmt.Fprint(f, `
-
 # Enable git-buildpackage to build using the currently checked out branch as if
 # it was the Debian branch. This makes it easier for contributors to develop and
 # test using feature/bugfix branches.


### PR DESCRIPTION
In commit af68dbf7 an extra tab char had seeped in. Remove it, and also add YAML separator so that the gitlab-ci.yml syntax is just like the one in salsa-ci.yml.

Fixes GitLab CI error:

    Unable to run pipeline
    `debian/gitlab-ci.yml`: (): found character that cannot start any token while scanning for the next token at line 4 column 1