### PR TITLE
make: add -https flag to use HTTPS git remote instead of SSH

### DIFF
--- a/create_salsa_project.go
+++ b/create_salsa_project.go
@@ -13,9 +13,14 @@ import (
 func execCreateSalsaProject(args []string) {
 	fs := flag.NewFlagSet("create-salsa-project", flag.ExitOnError)
 
+	useHTTPS := fs.Bool("https", false, "Use HTTPS remote URL instead of SSH")
+
 	fs.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s create-salsa-project <project-name>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Usage: %s create-salsa-project [FLAG]... <project-name>\n", os.Args[0])
 		fmt.Fprintf(os.Stderr, "Example: %s create-salsa-project golang-github-mattn-go-sqlite3\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "\n")
+		fmt.Fprintf(os.Stderr, "Flags:\n")
+		fs.PrintDefaults()
 	}
 
 	if err := fs.Parse(args); err != nil {
@@ -44,4 +49,6 @@ func execCreateSalsaProject(args []string) {
 		b, _ := io.ReadAll(resp.Body)
 		log.Fatalf("unexpected HTTP status code: got %d, want %d (response: %s)", got, want, string(b))
 	}
+
+	fmt.Printf("Project created. Remote URL: %s\n", salsaPackageURL(projectName, *useHTTPS))
 }

--- a/make.go
+++ b/make.go
@@ -416,8 +416,15 @@ func runGitCommandIn(dir string, arg ...string) error {
 	return cmd.Run()
 }
 
+func salsaPackageURL(debsrc string, useHTTPS bool) string {
+	if useHTTPS {
+		return fmt.Sprintf("https://salsa.debian.org/go-team/packages/%s.git", debsrc)
+	}
+	return fmt.Sprintf("git@salsa.debian.org:go-team/packages/%s.git", debsrc)
+}
+
 func createGitRepository(debsrc, gopkg, orig string, u *upstream,
-	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, pristineTar bool) (string, error) {
+	includeUpstreamHistory bool, allowUnknownHoster bool, debianBranch string, pristineTar bool, useHTTPS bool) (string, error) {
 	wd, err := os.Getwd()
 	if err != nil {
 		return "", fmt.Errorf("get cwd: %w", err)
@@ -449,7 +456,7 @@ func createGitRepository(debsrc, gopkg, orig string, u *upstream,
 
 	// [remote "origin"]
 
-	originURL := "git@salsa.debian.org:go-team/packages/" + debsrc + ".git"
+	originURL := salsaPackageURL(debsrc, useHTTPS)
 	log.Printf("Adding remote \"origin\" with URL %q\n", originURL)
 	if err := runGitCommandIn(dir, "remote", "add", "origin", originURL); err != nil {
 		return dir, fmt.Errorf("git remote add origin %s: %w", originURL, err)
@@ -722,6 +729,7 @@ func copyFile(src, dest string) error {
 
 func execMake(args []string, usage func()) {
 	fs := flag.NewFlagSet("make", flag.ExitOnError)
+	useHTTPS := fs.Bool("https", false, "Use HTTPS remote URL instead of SSH")
 	if usage != nil {
 		fs.Usage = usage
 	} else {
@@ -960,7 +968,8 @@ func execMake(args []string, usage func()) {
 
 	debversion := u.version + "-1"
 
-	dir, err := createGitRepository(debsrc, gopkg, orig, u, includeUpstreamHistory, allowUnknownHoster, debBranch, pristineTar)
+	dir, err := createGitRepository(debsrc, gopkg, orig, u,
+		includeUpstreamHistory, allowUnknownHoster, debBranch, pristineTar, *useHTTPS)
 	if err != nil {
 		log.Fatalf("Could not create git repository: %v\n", err)
 	}

--- a/make_test.go
+++ b/make_test.go
@@ -70,6 +70,37 @@ func TestDebianNameFromGopkg(t *testing.T) {
 	}
 }
 
+func TestSalsaPackageURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		debsrc   string
+		https    bool
+		expected string
+	}{
+		{
+			name:     "ssh",
+			debsrc:   "golang-github-mattn-go-sqlite3",
+			https:    false,
+			expected: "git@salsa.debian.org:go-team/packages/golang-github-mattn-go-sqlite3.git",
+		},
+		{
+			name:     "https",
+			debsrc:   "golang-github-mattn-go-sqlite3",
+			https:    true,
+			expected: "https://salsa.debian.org/go-team/packages/golang-github-mattn-go-sqlite3.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := salsaPackageURL(tt.debsrc, tt.https)
+			if got != tt.expected {
+				t.Errorf("salsaPackageURL(%q, %v) => %q, want %q", tt.debsrc, tt.https, got, tt.expected)
+			}
+		})
+	}
+}
+
 var tarballUrl = []struct {
 	repoRoot    string
 	tag         string


### PR DESCRIPTION
Fixes #199

Added a -https flag to the make subcommand. When passed, the git
remote origin is set to an HTTPS URL instead of the default SSH URL.

SSH remains the default->>no breaking change.

Tested with:
- go build ./...
- go test ./...
- ./dh-make-golang make -help (flag appears correctly)