### PR TITLE
Fix nil pointer dereference in filepath.Walk callback in forceRemoveAll

### DIFF
--- a/fs_utils.go
+++ b/fs_utils.go
@@ -10,17 +10,28 @@ import (
 // harder to remove all the files and directories.
 func forceRemoveAll(path string) error {
 	// first pass to make sure all the directories are writable
-	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
-		if info.IsDir() {
-			return os.Chmod(path, 0777)
-		} else {
-			// remove files by the way
-			return os.Remove(path)
+	err := filepath.Walk(path, func(p string, info fs.FileInfo, err error) error {
+		// IMPORTANT: always check err first
+		if err != nil {
+			return err
 		}
+
+		if info == nil {
+			return nil
+		}
+
+		if info.IsDir() {
+			return os.Chmod(p, 0777)
+		}
+
+		// remove files
+		return os.Remove(p)
 	})
+
 	if err != nil {
 		return err
 	}
+
 	// remove the remaining directories
 	return os.RemoveAll(path)
 }


### PR DESCRIPTION
## Summary
This PR fixes a potential nil pointer dereference in `forceRemoveAll` in `fs_utils.go`.

`filepath.Walk` may invoke the callback with `err != nil` and `info == nil` (for example, in cases of permission errors or inaccessible paths). The previous implementation directly called `info.IsDir()` without checking for a nil `info`, which could cause a runtime panic.

## Fix
- Added a guard to check `err` before using `info`
- Added a nil check for `info` to prevent panics
- Refactored variable name from `path` to `p` to avoid shadowing
- Simplified control flow for readability

## Before
- Directly accessed `info.IsDir()` without nil checks
- Risk of panic when `info == nil`

## After
- Safely handles `err` and `info == nil`
- Prevents crashes during filesystem traversal
- Keeps original behavior of chmod for directories and remove for files

## Impact
- Prevents runtime panic in `forceRemoveAll`
- Improves robustness when encountering permission errors or broken filesystem entries