### PR TITLE
Prevent nil pointer dereference in forceRemoveAll

### DIFF
--- a/fs_utils.go
+++ b/fs_utils.go
@@ -11,6 +11,9 @@ import (
 func forceRemoveAll(path string) error {
 	// first pass to make sure all the directories are writable
 	err := filepath.Walk(path, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() {
 			return os.Chmod(path, 0777)
 		} else {


### PR DESCRIPTION
Check that `err` is `nil` before using `info.IsDir()`, this allows returning a proper error message instead of panicking by dereferencing a nil pointer.

This extracts the most important change of #319, as it was closed by its author.
